### PR TITLE
「リリース日」の列の表示崩れを修正

### DIFF
--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -111,14 +111,14 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="recording in recording_data" :key="recording.id">
+        <tr v-for="recording in recording_data" :key="recording.id" class="border px-4 py-2">
           <td class="border px-4 py-2 max-w-[600px]">
             <RouterLink v-bind:to="{name: 'RecordingDetail', params: {id: recording.id}}">
               {{ recording.title }}
             </RouterLink>
           </td>
           <td class="border px-4 py-2">{{ recording["artist-credit"].map((credit: ArtistCredit) => credit.all_name).join(' ') }}</td>
-          <td class="text-center border px-4 py-2 w-[130px] hidden md:inline-block">{{ recording.first_release_date }}</td>
+          <td class="text-center px-4 py-2 w-[130px] hidden md:inline-block">{{ recording.first_release_date }}</td>
         </tr>
       </tbody>
     </table>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -113,14 +113,14 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="recording in recording_data" :key="recording.id">
-          <td class="border px-4 py-2">
+        <tr v-for="recording in recording_data" :key="recording.id" class="border px-4 py-2">
+          <td class="border px-4 py-2 max-w-[600px]">
             <RouterLink v-bind:to="{name: 'RecordingDetail', params: {id: recording.id}}">
               {{ recording.title }}
             </RouterLink>
           </td>
           <td class="border px-4 py-2">{{ recording["artist-credit"].map((credit: ArtistCredit) => credit.all_name).join(' ') }}</td>
-          <td class="text-center border px-4 py-2 hidden md:inline-block">{{ recording.first_release_date }}</td>
+          <td class="text-center px-4 py-2 w-[130px] hidden md:inline-block">{{ recording.first_release_date }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credit_search/issues/183

## 概要
楽曲検索画面&フィルター画面の「リリース日」列の表示が崩れていたのを修正。2行以上になると崩れていた。