### PR TITLE
テストコードをわかりやすくした

### DIFF
--- a/cypress/component/ArtistDetail.cy.ts
+++ b/cypress/component/ArtistDetail.cy.ts
@@ -19,10 +19,10 @@ describe('ArtistDetail tests', () => {
     cy.wait('@yasutakaRelationshipRequest')
     cy.wait('@yasutakaRecording1PageRequest')
 
-    cy.get('.text-2xl').contains('中田ヤスタカ')
+    cy.get('.artist-name').contains('中田ヤスタカ')
     cy.get('h1').contains('中田ヤスタカ')
 
-    cy.get(':nth-child(2) > .text-xl').contains('作詞作曲した音源')
+    cy.get('.songwriter-caption').contains('作詞作曲した音源')
     cy.get('.songwriter-table > tbody > :nth-child(1) > .text-center').contains(
       'composer'
     )
@@ -30,21 +30,19 @@ describe('ArtistDetail tests', () => {
       '.songwriter-table > tbody > :nth-child(1) > :nth-child(2)'
     ).contains('1mm')
 
-    //担当がcomposerが476件ちょうどか
     cy.get('.songwriter-table > tbody > tr > td')
       .filter(':contains("composer")')
       .should(($trs) => {
         expect($trs, '476 items').to.have.length(476)
       })
 
-    //担当がlyricistが310件ちょうどか
     cy.get('.songwriter-table > tbody > tr > td')
       .filter(':contains("lyricist")')
       .should(($trs) => {
         expect($trs, '310 items').to.have.length(310)
       })
 
-    cy.get(':nth-child(4) > .text-xl').contains('スタッフとして関わった音源')
+    cy.get('.staff-caption').contains('スタッフとして関わった音源')
     cy.get('.staff-table > tbody > :nth-child(2) > .text-center').contains(
       'arranger'
     )
@@ -52,42 +50,53 @@ describe('ArtistDetail tests', () => {
       '5iVE YEARS MONSTER'
     )
 
-    //担当がproducerが172件ちょうどか
     cy.get('.staff-table > tbody > tr > td')
       .filter(':contains("producer")')
       .should(($trs) => {
         expect($trs, '172 items').to.have.length(172)
       })
 
-    cy.get(':nth-child(6) > .text-xl').contains(
+    cy.get('.artist-caption').contains(
       'アーティストとして関わった音源'
     )
     cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
       '一番歌 (Extend-mix)'
     )
 
-    // アーティスト音源1ページ目が100件か
     cy.get('.artist-table > tbody > tr > td').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
-    cy.get('p').contains('105 件中 1 〜 100件')
+    cy.get('.artist-recording-number').contains('105 件中 1 〜 100件')
+  })
 
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > :nth-child(7)')
-    cy.get(':nth-child(2) > .paginate-buttons').contains('1')
+  it('Check recording of songwriter and staff results are not change by using pagination', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/artist/53bfc28e-2c48-4776-8949-1953c78dd187?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
+      { fixture: 'mock_nakatayasutaka_relationship.json' }
+    ).as('yasutakaRelationshipRequest')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording?artist=53bfc28e-2c48-4776-8949-1953c78dd187&offset=0&limit=100&fmt=json',
+      { fixture: 'mock_nakatayasutaka_recording_page1.json' }
+    ).as('yasutakaRecording1PageRequest')
+    cy.mount(ArtistDetail, {
+      props: { id: '53bfc28e-2c48-4776-8949-1953c78dd187' },
+    } as OptionsParam)
+    cy.wait('@yasutakaRelationshipRequest')
+    cy.wait('@yasutakaRecording1PageRequest')
 
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording?artist=53bfc28e-2c48-4776-8949-1953c78dd187&offset=100&limit=100&fmt=json',
       { fixture: 'mock_nakatayasutaka_recording_page2.json' }
     ).as('yasutakaRecording2PageRequest')
-    cy.get(':nth-child(4) > .paginate-buttons').contains('>').click()
+    cy.get('.pagination').contains('>').click()
     cy.wait('@yasutakaRecording2PageRequest')
 
-    // 以下、アーティスト音源のページを切り替えてもRelationshipsのデータに変化がないかテスト
-    cy.get('.text-2xl').contains('中田ヤスタカ')
+    cy.get('.artist-name').contains('中田ヤスタカ')
 
-    cy.get(':nth-child(2) > .text-xl').contains('作詞作曲した音源')
+    cy.get('.songwriter-caption').contains('作詞作曲した音源')
     cy.get('.songwriter-table > tbody > :nth-child(1) > .text-center').contains(
       'composer'
     )
@@ -107,7 +116,7 @@ describe('ArtistDetail tests', () => {
         expect($trs, '310 items').to.have.length(310)
       })
 
-    cy.get(':nth-child(4) > .text-xl').contains('スタッフとして関わった音源')
+    cy.get('.staff-caption').contains('スタッフとして関わった音源')
     cy.get('.staff-table > tbody > :nth-child(2) > .text-center').contains(
       'arranger'
     )
@@ -120,26 +129,19 @@ describe('ArtistDetail tests', () => {
       .should(($trs) => {
         expect($trs, '172 items').to.have.length(172)
       })
-    // ここまで1ページ目のテストと同じ
+      cy.get('.artist-caption').contains(
+        'アーティストとして関わった音源'
+      )
+      cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
+        '透明 toumei'
+      )
 
-    cy.get(':nth-child(6) > .text-xl').contains(
-      'アーティストとして関わった音源'
-    )
-    cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
-      '透明 toumei'
-    )
+      cy.get('.artist-table > tbody > tr > td').should(($trs) => {
+        expect($trs, '5 items').to.have.length(5)
+      })
+      cy.get('.artist-recording-number').contains('105 件中 101 〜 105件')
 
-    // アーティスト音源2ページ目が5件か
-    cy.get('.artist-table > tbody > tr > td').should(($trs) => {
-      expect($trs, '5 items').to.have.length(5)
-    })
-    cy.get('p').contains('105 件中 101 〜 105件')
-
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > :nth-child(7)')
-    cy.get(':nth-child(2) > .paginate-buttons').contains('1')
-    cy.get(':nth-child(4) > .paginate-buttons').contains('>')
-    cy.get(':nth-child(5) > .paginate-buttons').should('not.be')
+      cy.get('.pagination')
   })
 
   it('Artist have songwriter and staff tables', () => {
@@ -160,9 +162,9 @@ describe('ArtistDetail tests', () => {
     cy.wait('@otohaRelationshipRequest')
     cy.wait('@otohaRecordingRequest')
 
-    cy.get('.text-2xl').contains('音羽-otoha-')
+    cy.get('.artist-name').contains('音羽-otoha-')
 
-    cy.get(':nth-child(2) > .text-xl').contains('作詞作曲した音源')
+    cy.get('.songwriter-caption').contains('作詞作曲した音源')
     cy.get('.songwriter-table > tbody > :nth-child(1) > .text-center').contains(
       'composer'
     )
@@ -170,7 +172,7 @@ describe('ArtistDetail tests', () => {
       '.songwriter-table > tbody > :nth-child(1) > :nth-child(2)'
     ).contains('ギターと孤独と蒼い惑星')
 
-    cy.get(':nth-child(4) > .text-xl').contains('スタッフとして関わった音源')
+    cy.get('.staff-caption').contains('スタッフとして関わった音源')
     cy.get('.staff-table > tbody > :nth-child(1) > .text-center').contains(
       'guitar'
     )
@@ -178,11 +180,8 @@ describe('ArtistDetail tests', () => {
       '【LIVE映像】「青春コンプレックス」/ ぼっち・ざ・ろっく！-SPECIAL STUDIO LIVE-'
     )
 
-    //アーティスト音源の表が存在していないかどうか
     cy.get('.artist-table > tbody').should('not.be')
-
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('Artist have songwriter and artist tables', () => {
@@ -202,9 +201,9 @@ describe('ArtistDetail tests', () => {
     cy.wait('@higuchiaiRelationshipRequest')
     cy.wait('@higuchiaiRecordingRequest')
 
-    cy.get('.text-2xl').contains('ヒグチアイ')
+    cy.get('.artist-name').contains('ヒグチアイ')
 
-    cy.get(':nth-child(2) > .text-xl').contains('作詞作曲した音源')
+    cy.get('.songwriter-caption').contains('作詞作曲した音源')
     cy.get('.songwriter-table > tbody > :nth-child(1) > .text-center').contains(
       'composer'
     )
@@ -212,24 +211,20 @@ describe('ArtistDetail tests', () => {
       '.songwriter-table > tbody > :nth-child(1) > :nth-child(2)'
     ).contains('悪魔の子')
 
-    cy.get(':nth-child(5) > .text-xl').contains(
+    cy.get('.artist-caption').contains(
       'アーティストとして関わった音源'
     )
     cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
       '妄想悩殺お手ガール'
     )
 
-    // アーティスト音源が87件か
     cy.get('.artist-table > tbody > tr > td').should(($trs) => {
       expect($trs, '87 items').to.have.length(87)
     })
-    cy.get('p').contains('87 件中 1 〜 87件')
+    cy.get('.artist-recording-number').contains('87 件中 1 〜 87件')
 
-    //スタッフ音源の表が存在していないかどうか
     cy.get('.staff-table > tbody').should('not.be')
-
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('Artist have staff and artist tables', () => {
@@ -249,9 +244,9 @@ describe('ArtistDetail tests', () => {
     cy.wait('@soritaRelationshipRequest')
     cy.wait('@soritaRecordingRequest')
 
-    cy.get('.text-2xl').contains('反田恭平')
+    cy.get('.artist-name').contains('反田恭平')
 
-    cy.get(':nth-child(3) > .text-xl').contains('スタッフとして関わった音源')
+    cy.get('.staff-caption').contains('スタッフとして関わった音源')
     cy.get('.staff-table > tbody > :nth-child(1) > .text-center').contains(
       'piano'
     )
@@ -259,24 +254,20 @@ describe('ArtistDetail tests', () => {
       'Rhapsody on a Theme of Paganini, op. 43: 1. Introduction. Allegro vivace'
     )
 
-    cy.get(':nth-child(5) > .text-xl').contains(
+    cy.get('.artist-caption').contains(
       'アーティストとして関わった音源'
     )
     cy.get('.artist-table > tbody > :nth-child(2) > .px-4').contains(
       'ワルツ第6番 変ニ長調 作品64-1 「小犬のワルツ」'
     )
 
-    // アーティスト音源が87件か
     cy.get('.artist-table > tbody > tr > td').should(($trs) => {
       expect($trs, '31 items').to.have.length(31)
     })
-    cy.get('p').contains('31 件中 1 〜 31件')
+    cy.get('.artist-recording-number').contains('31 件中 1 〜 31件')
 
-    //作詞作曲の音源の表が存在していないかどうか
     cy.get('.songwriter-table > tbody').should('not.be')
-
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('Artist have only songwriter table', () => {
@@ -296,9 +287,9 @@ describe('ArtistDetail tests', () => {
     cy.wait('@hinataRelationshipRequest')
     cy.wait('@hinataRecordingRequest')
 
-    cy.get('.text-2xl').contains('仰木日向')
+    cy.get('.artist-name').contains('仰木日向')
 
-    cy.get(':nth-child(2) > .text-xl').contains('作詞作曲した音源')
+    cy.get('.songwriter-caption').contains('作詞作曲した音源')
     cy.get('.songwriter-table > tbody > :nth-child(1) > .text-center').contains(
       'composer'
     )
@@ -306,14 +297,9 @@ describe('ArtistDetail tests', () => {
       '.songwriter-table > tbody > :nth-child(1) > :nth-child(2)'
     ).contains('彩花囃子（イロドリハナバヤシ）')
 
-    //スタッフ音源の表が存在していないかどうか
     cy.get('.staff-table > tbody').should('not.be')
-
-    //アーティスト音源の表が存在していないかどうか
     cy.get('.artist-table > tbody').should('not.be')
-
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('Artist have only staff table', () => {
@@ -333,9 +319,9 @@ describe('ArtistDetail tests', () => {
     cy.wait('@kawasakiRelationshipRequest')
     cy.wait('@kawasakiRecordingRequest')
 
-    cy.get('.text-2xl').contains('川崎亘一')
+    cy.get('.artist-name').contains('川崎亘一')
 
-    cy.get(':nth-child(3) > .text-xl').contains('スタッフとして関わった音源')
+    cy.get('.staff-caption').contains('スタッフとして関わった音源')
     cy.get('.staff-table > tbody > :nth-child(1) > .text-center').contains(
       'guitar'
     )
@@ -343,14 +329,9 @@ describe('ArtistDetail tests', () => {
       'Be mine!'
     )
 
-    //作詞作曲の音源の表が存在していないかどうか
     cy.get('.songwriter-table > tbody').should('not.be')
-
-    //アーティスト音源の表が存在していないかどうか
     cy.get('.artist-table > tbody').should('not.be')
-
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('Artist have only artist table', () => {
@@ -370,24 +351,18 @@ describe('ArtistDetail tests', () => {
     cy.wait('@aragakiRelationshipRequest')
     cy.wait('@aragakiRecordingRequest')
 
-    cy.get('.text-2xl').contains('新垣結衣')
+    cy.get('.artist-name').contains('新垣結衣')
 
-    cy.get('.text-xl').contains('アーティストとして関わった音源')
+    cy.get('.artist-caption').contains('アーティストとして関わった音源')
     cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains('あいたい')
 
-    // アーティスト音源が87件か
     cy.get('.artist-table > tbody > tr > td').should(($trs) => {
       expect($trs, '74 items').to.have.length(74)
     })
-    cy.get('p').contains('74 件中 1 〜 74件')
+    cy.get('.artist-recording-number').contains('74 件中 1 〜 74件')
 
-    //作詞作曲の音源の表が存在していないかどうか
     cy.get('.songwriter-table > tbody').should('not.be')
-
-    //スタッフ音源の表が存在していないかどうか
     cy.get('.staff-table > tbody').should('not.be')
-
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 })

--- a/cypress/component/ArtistDetail.cy.ts
+++ b/cypress/component/ArtistDetail.cy.ts
@@ -56,9 +56,7 @@ describe('ArtistDetail tests', () => {
         expect($trs, '172 items').to.have.length(172)
       })
 
-    cy.get('.artist-caption').contains(
-      'アーティストとして関わった音源'
-    )
+    cy.get('.artist-caption').contains('アーティストとして関わった音源')
     cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
       '一番歌 (Extend-mix)'
     )
@@ -129,19 +127,17 @@ describe('ArtistDetail tests', () => {
       .should(($trs) => {
         expect($trs, '172 items').to.have.length(172)
       })
-      cy.get('.artist-caption').contains(
-        'アーティストとして関わった音源'
-      )
-      cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
-        '透明 toumei'
-      )
+    cy.get('.artist-caption').contains('アーティストとして関わった音源')
+    cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
+      '透明 toumei'
+    )
 
-      cy.get('.artist-table > tbody > tr > td').should(($trs) => {
-        expect($trs, '5 items').to.have.length(5)
-      })
-      cy.get('.artist-recording-number').contains('105 件中 101 〜 105件')
+    cy.get('.artist-table > tbody > tr > td').should(($trs) => {
+      expect($trs, '5 items').to.have.length(5)
+    })
+    cy.get('.artist-recording-number').contains('105 件中 101 〜 105件')
 
-      cy.get('.pagination')
+    cy.get('.pagination')
   })
 
   it('Artist have songwriter and staff tables', () => {
@@ -211,9 +207,7 @@ describe('ArtistDetail tests', () => {
       '.songwriter-table > tbody > :nth-child(1) > :nth-child(2)'
     ).contains('悪魔の子')
 
-    cy.get('.artist-caption').contains(
-      'アーティストとして関わった音源'
-    )
+    cy.get('.artist-caption').contains('アーティストとして関わった音源')
     cy.get('.artist-table > tbody > :nth-child(1) > .px-4').contains(
       '妄想悩殺お手ガール'
     )
@@ -254,9 +248,7 @@ describe('ArtistDetail tests', () => {
       'Rhapsody on a Theme of Paganini, op. 43: 1. Introduction. Allegro vivace'
     )
 
-    cy.get('.artist-caption').contains(
-      'アーティストとして関わった音源'
-    )
+    cy.get('.artist-caption').contains('アーティストとして関わった音源')
     cy.get('.artist-table > tbody > :nth-child(2) > .px-4').contains(
       'ワルツ第6番 変ニ長調 作品64-1 「小犬のワルツ」'
     )

--- a/cypress/component/ArtistDetail.cy.ts
+++ b/cypress/component/ArtistDetail.cy.ts
@@ -136,8 +136,6 @@ describe('ArtistDetail tests', () => {
       expect($trs, '5 items').to.have.length(5)
     })
     cy.get('.artist-recording-number').contains('105 件中 101 〜 105件')
-
-    cy.get('.pagination')
   })
 
   it('Artist have songwriter and staff tables', () => {

--- a/cypress/component/ArtistSearch.cy.ts
+++ b/cypress/component/ArtistSearch.cy.ts
@@ -37,9 +37,6 @@ describe('ArtistSearch tests', () => {
     })
     cy.get('.artist-search-number').contains('検索結果 2479 件中 1 〜 100件')
 
-    cy.get('.pagination').contains('1')
-    cy.get('.last-button').contains('25')
-
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/?query=artist:%E5%B0%8F%E5%AE%A4%E5%93%B2%E5%93%89&offset=100&limit=100&fmt=json',
@@ -71,6 +68,7 @@ describe('ArtistSearch tests', () => {
     cy.get('.artist-search-number').contains(
       '検索結果 2479 件中 2401 〜 2479件'
     )
+    cy.get('.pagination')
   })
 
   it('No result', () => {

--- a/cypress/component/ArtistSearch.cy.ts
+++ b/cypress/component/ArtistSearch.cy.ts
@@ -11,18 +11,16 @@ describe('ArtistSearch tests', () => {
     cy.wait('@kenmochihidefumiRequest')
     cy.get('h1').contains('人物検索結果')
 
-    cy.get('.table-auto > tbody > :nth-child(1) >  > :nth-child(1)').contains(
+    cy.get('.artist-search-table > tbody').contains(
       'ケンモチヒデフミ'
     )
 
-    //検索結果が1件ちょうどか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '1 item').to.have.length(1)
     })
-    cy.get('p').contains('検索結果 1 件中 1 〜 1件')
+    cy.get('.artist-search-number').contains('検索結果 1 件中 1 〜 1件')
 
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('More than 100 recording search result', () => {
@@ -34,41 +32,35 @@ describe('ArtistSearch tests', () => {
     cy.mount(ArtistSearch, { query: { term: '小室哲哉' } })
     cy.wait('@komurotetsuya1PageRequest')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.artist-search-table > tbody').contains(
       '小室哲哉'
     )
 
-    //検索結果が100件ちょうどか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
-    cy.get('p').contains('検索結果 2479 件中 1 〜 100件')
+    cy.get('.artist-search-number').contains('検索結果 2479 件中 1 〜 100件')
 
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div')
-    cy.get(':nth-child(2) > .paginate-buttons').contains('1')
+    cy.get('.pagination').contains('1')
     cy.get('.last-button').contains('25')
 
-    //2ページ目
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/?query=artist:%E5%B0%8F%E5%AE%A4%E5%93%B2%E5%93%89&offset=100&limit=100&fmt=json',
       { fixture: 'mock_komurotetsuya_page2.json' }
     ).as('komurotetsuya2PageRequest')
-    cy.get(':nth-child(7) > .paginate-buttons').contains('>').click()
+    cy.get('.pagination').contains('>').click()
     cy.wait('@komurotetsuya2PageRequest')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.artist-search-table > tbody').contains(
       '小久保隆'
     )
 
-    //検索結果が100件ちょうどか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
-    cy.get('p').contains('検索結果 2479 件中 101 〜 200件')
+    cy.get('.artist-search-number').contains('検索結果 2479 件中 101 〜 200件')
 
-    //最後のページ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/?query=artist:%E5%B0%8F%E5%AE%A4%E5%93%B2%E5%93%89&offset=2400&limit=100&fmt=json',
@@ -77,19 +69,17 @@ describe('ArtistSearch tests', () => {
     cy.get('.last-button').click()
     cy.wait('@komurotetsuyaLastPageRequest')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.artist-search-table > tbody').contains(
       '小山田祐治'
     )
 
-    //検索結果が79件か
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '79 items').to.have.length(79)
     })
-    cy.get('p').contains('検索結果 2479 件中 2401 〜 2479件')
+    cy.get('.artist-search-number').contains('検索結果 2479 件中 2401 〜 2479件')
   })
 
   it('No result', () => {
-    //検索結果が0件
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/?query=artist:%E3%81%86%E3%81%87%EF%BD%93%EF%BD%92%EF%BD%84%EF%BD%86%EF%BD%94%EF%BD%96%EF%BD%87%EF%BD%99%EF%BD%82%EF%BD%88%E3%82%93%EF%BD%8A%EF%BD%8B%EF%BD%8D%EF%BD%8C%E3%80%81%E3%80%82%E3%80%81%EF%BD%8D%E3%82%93%EF%BD%87%EF%BD%82%EF%BD%86%EF%BD%84%EF%BD%96%EF%BD%93&offset=0&limit=100&fmt=json',
@@ -102,11 +92,10 @@ describe('ArtistSearch tests', () => {
     })
     cy.wait('@noArtistRequest')
 
-    cy.get('h1').contains('Not Found!')
-    cy.get('p').contains('見つかりませんでした。')
+    cy.get('.no-result-caption').contains('Not Found!')
+    cy.get('.no-result > p').contains('見つかりませんでした。')
 
-    //1件も表示されていないか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '0 item').to.have.length(0)
     })
   })

--- a/cypress/component/ArtistSearch.cy.ts
+++ b/cypress/component/ArtistSearch.cy.ts
@@ -11,9 +11,7 @@ describe('ArtistSearch tests', () => {
     cy.wait('@kenmochihidefumiRequest')
     cy.get('h1').contains('人物検索結果')
 
-    cy.get('.artist-search-table > tbody').contains(
-      'ケンモチヒデフミ'
-    )
+    cy.get('.artist-search-table > tbody').contains('ケンモチヒデフミ')
 
     cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '1 item').to.have.length(1)
@@ -32,9 +30,7 @@ describe('ArtistSearch tests', () => {
     cy.mount(ArtistSearch, { query: { term: '小室哲哉' } })
     cy.wait('@komurotetsuya1PageRequest')
 
-    cy.get('.artist-search-table > tbody').contains(
-      '小室哲哉'
-    )
+    cy.get('.artist-search-table > tbody').contains('小室哲哉')
 
     cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
@@ -52,9 +48,7 @@ describe('ArtistSearch tests', () => {
     cy.get('.pagination').contains('>').click()
     cy.wait('@komurotetsuya2PageRequest')
 
-    cy.get('.artist-search-table > tbody').contains(
-      '小久保隆'
-    )
+    cy.get('.artist-search-table > tbody').contains('小久保隆')
 
     cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
@@ -69,14 +63,14 @@ describe('ArtistSearch tests', () => {
     cy.get('.last-button').click()
     cy.wait('@komurotetsuyaLastPageRequest')
 
-    cy.get('.artist-search-table > tbody').contains(
-      '小山田祐治'
-    )
+    cy.get('.artist-search-table > tbody').contains('小山田祐治')
 
     cy.get('.artist-search-table > tbody > tr').should(($trs) => {
       expect($trs, '79 items').to.have.length(79)
     })
-    cy.get('.artist-search-number').contains('検索結果 2479 件中 2401 〜 2479件')
+    cy.get('.artist-search-number').contains(
+      '検索結果 2479 件中 2401 〜 2479件'
+    )
   })
 
   it('No result', () => {

--- a/cypress/component/RecordingDetail.cy.ts
+++ b/cypress/component/RecordingDetail.cy.ts
@@ -19,10 +19,9 @@ describe('RecordingDetail tests', () => {
     cy.wait('@suiheisenRequest')
     cy.wait('@suiheisenSpotifyRequest')
 
-    cy.get('.text-2xl').contains('水平線')
-    cy.get('h1').contains('水平線')
-    cy.get('p.break-all > span > a').contains('back number')
-    cy.get('.bg-blue-400 > a').should(
+    cy.get('.recording-title').contains('水平線')
+    cy.get('.artist-name').contains('back number')
+    cy.get('.spotify-button > a').should(
       'have.attr',
       'href',
       'https://open.spotify.com/track/3RvdkNMcSy71m0aT6UF9Uf'
@@ -46,8 +45,8 @@ describe('RecordingDetail tests', () => {
     cy.wait('@butterSugarCreamRequest')
     cy.wait('@butterSugarCreamSpotifyRequest')
 
-    cy.get('.text-2xl').contains('Butter Sugar Cream (instrumental)')
-    cy.get('p.break-all').contains('Tomggg feat. tsvaci')
-    cy.get('.bg-blue-400').should('be.disabled')
+    cy.get('.recording-title').contains('Butter Sugar Cream (instrumental)')
+    cy.get('.artist-name').contains('Tomggg feat. tsvaci')
+    cy.get('.spotify-button').should('be.disabled')
   })
 })

--- a/cypress/component/RecordingInWork.cy.ts
+++ b/cypress/component/RecordingInWork.cy.ts
@@ -14,8 +14,7 @@ describe('RecordingInWork tests', () => {
     cy.wait('@debbyRequest')
     cy.get('h1').contains('曲群一覧')
 
-    //曲数が127件ちょうどか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.work-table > tbody > tr').should(($trs) => {
       expect($trs, '127 items').to.have.length(127)
     })
   })
@@ -31,8 +30,7 @@ describe('RecordingInWork tests', () => {
     } as OptionsParam)
     cy.wait('@umaRequest')
 
-    //曲数が44件ちょうどか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.work-table > tbody > tr').should(($trs) => {
       expect($trs, '44 items').to.have.length(44)
     })
   })

--- a/cypress/component/RecordingSearch.cy.ts
+++ b/cypress/component/RecordingSearch.cy.ts
@@ -11,24 +11,22 @@ describe('RecordingSearch tests', () => {
     cy.wait('@mixednutsRequest')
 
     cy.get('h1').contains('音源検索結果')
-    cy.get('.table-auto > tbody > :nth-child(1) >  > :nth-child(1)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) >  > :nth-child(1)').contains(
       'ミックスナッツ'
     )
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(2)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
       'Official髭男dism'
     )
     cy.get(
-      '.table-auto > tbody > :nth-child(1) > :nth-child(2) > .my-1'
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2) > .release-date'
     ).contains('2022-04-15')
 
-    //曲名が3件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '3 items').to.have.length(3)
     })
-    cy.get('.container > :nth-child(4)').contains('検索結果 3 件中 1 〜 3件')
+    cy.get('.recording-search-number').contains('検索結果 3 件中 1 〜 3件')
 
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('.container > :nth-child(5)').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('More than 100 recording search result', () => {
@@ -40,86 +38,75 @@ describe('RecordingSearch tests', () => {
     cy.mount(RecordingSearch, { query: { term: 'アイドル' } })
     cy.wait('@idol1PageRequest')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
       'アイドル'
     )
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(2)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
       '星勝'
     )
     cy.get(
-      '.table-auto > tbody > :nth-child(1) > :nth-child(2) > .my-1'
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2) > .release-date'
     ).contains('1990-12-28')
 
-    //曲名が100件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
-    cy.get('.container > :nth-child(4)').contains(
+    cy.get('.recording-search-number').contains(
       '検索結果 249 件中 1 〜 100件'
     )
 
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('.container > :nth-child(5)')
-    cy.get(':nth-child(4) > .paginate-buttons').contains('3')
-
-    //2ページ目に遷移
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E3%82%A2%E3%82%A4%E3%83%89%E3%83%AB&offset=100&limit=100&fmt=json',
       { fixture: 'mock_idol_page2.json' }
     ).as('idol2PageRequest')
-    cy.get(':nth-child(5) > .paginate-buttons').contains('>').click()
+    cy.get('.pagination').contains('>').click()
     cy.wait('@idol2PageRequest')
 
-    cy.viewport('iphone-se2')
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
       'アイドル活動！'
     )
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(2)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
       '風鈴ぼるけいの'
     )
     cy.get(
-      '.table-auto > tbody > :nth-child(1) > :nth-child(2)  > .my-1'
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2)  > .release-date'
     ).contains('2018-03-04')
 
-    //曲名が100件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
-    cy.get('.container > :nth-child(4)').contains(
+    cy.get('.recording-search-number').contains(
       '検索結果 249 件中 101 〜 200件'
     )
 
-    //3ページ目に遷移
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E3%82%A2%E3%82%A4%E3%83%89%E3%83%AB&offset=200&limit=100&fmt=json',
       { fixture: 'mock_idol_page3.json' }
     ).as('idol3PageRequest')
-    cy.get(':nth-child(5) > .paginate-buttons').contains('>').click()
+    cy.get('.pagination').contains('>').click()
     cy.wait('@idol3PageRequest')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
       '全力アイドル (M@STER VERSION) (オリジナル・カラオケ)'
     )
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(2)').contains(
+    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
       '水瀬伊織 (CV: 釘宮理恵 )'
     )
     cy.get(
-      '.table-auto > tbody > :nth-child(1) > :nth-child(2) > .my-1'
+      '.recording-search-table> tbody > :nth-child(1) > :nth-child(2) > .release-date'
     ).contains('2015-06-03')
 
-    //曲名が49件か
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '49 items').to.have.length(49)
     })
-    cy.get('.container > :nth-child(4)').contains(
+    cy.get('.recording-search-number').contains(
       '検索結果 249 件中 201 〜 249件'
     )
   })
 
   it('No result', () => {
-    //検索結果が0件
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E3%81%84%E3%81%88%E3%81%98%E3%81%8A%E3%81%88%E3%81%AC%EF%BD%82%E3%81%AE%E3%81%84%E3%81%BF%E3%81%8A%E3%81%88%EF%BD%8E&offset=0&limit=100&fmt=json',
@@ -130,10 +117,8 @@ describe('RecordingSearch tests', () => {
     })
     cy.wait('@noRecordingRequest')
 
-    cy.get('p').contains('見つかりませんでした。')
-
-    //1件も表示されていないか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.no-result > p').contains('見つかりませんでした。')
+    cy.get('.recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '0 item').to.have.length(0)
     })
   })

--- a/cypress/component/RecordingSearch.cy.ts
+++ b/cypress/component/RecordingSearch.cy.ts
@@ -11,12 +11,12 @@ describe('RecordingSearch tests', () => {
     cy.wait('@mixednutsRequest')
 
     cy.get('h1').contains('音源検索結果')
-    cy.get('.recording-search-table > tbody > :nth-child(1) >  > :nth-child(1)').contains(
-      'ミックスナッツ'
-    )
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
-      'Official髭男dism'
-    )
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) >  > :nth-child(1)'
+    ).contains('ミックスナッツ')
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('Official髭男dism')
     cy.get(
       '.recording-search-table > tbody > :nth-child(1) > :nth-child(2) > .release-date'
     ).contains('2022-04-15')
@@ -38,12 +38,12 @@ describe('RecordingSearch tests', () => {
     cy.mount(RecordingSearch, { query: { term: 'アイドル' } })
     cy.wait('@idol1PageRequest')
 
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
-      'アイドル'
-    )
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
-      '星勝'
-    )
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(1)'
+    ).contains('アイドル')
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('星勝')
     cy.get(
       '.recording-search-table > tbody > :nth-child(1) > :nth-child(2) > .release-date'
     ).contains('1990-12-28')
@@ -51,9 +51,7 @@ describe('RecordingSearch tests', () => {
     cy.get('.recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
-    cy.get('.recording-search-number').contains(
-      '検索結果 249 件中 1 〜 100件'
-    )
+    cy.get('.recording-search-number').contains('検索結果 249 件中 1 〜 100件')
 
     cy.intercept(
       'GET',
@@ -63,12 +61,12 @@ describe('RecordingSearch tests', () => {
     cy.get('.pagination').contains('>').click()
     cy.wait('@idol2PageRequest')
 
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
-      'アイドル活動！'
-    )
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
-      '風鈴ぼるけいの'
-    )
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(1)'
+    ).contains('アイドル活動！')
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('風鈴ぼるけいの')
     cy.get(
       '.recording-search-table > tbody > :nth-child(1) > :nth-child(2)  > .release-date'
     ).contains('2018-03-04')
@@ -88,12 +86,12 @@ describe('RecordingSearch tests', () => {
     cy.get('.pagination').contains('>').click()
     cy.wait('@idol3PageRequest')
 
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
-      '全力アイドル (M@STER VERSION) (オリジナル・カラオケ)'
-    )
-    cy.get('.recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
-      '水瀬伊織 (CV: 釘宮理恵 )'
-    )
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(1)'
+    ).contains('全力アイドル (M@STER VERSION) (オリジナル・カラオケ)')
+    cy.get(
+      '.recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('水瀬伊織 (CV: 釘宮理恵 )')
     cy.get(
       '.recording-search-table> tbody > :nth-child(1) > :nth-child(2) > .release-date'
     ).contains('2015-06-03')

--- a/cypress/component/RecordingSearchFilter.cy.ts
+++ b/cypress/component/RecordingSearchFilter.cy.ts
@@ -37,14 +37,16 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue5Request')
 
     cy.get('h1').contains('絞り込み結果')
-    cy.get('.filtered-recording-search-number').contains('検索結果 124 件中 1 〜 100件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 124 件中 1 〜 100件'
+    )
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
-      '上を向いて歩こう'
-    )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
-      '長渕剛'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('長渕剛')
 
     cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("上を向いて歩こう")')
@@ -53,7 +55,9 @@ describe('RecordingSearchFilter tests', () => {
       })
 
     cy.get('.pagination').contains('2').click()
-    cy.get('.filtered-recording-search-number').contains('検索結果 124 件中 101 〜 124件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 124 件中 101 〜 124件'
+    )
 
     cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("上を向いて歩こう")')
@@ -97,26 +101,32 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.filtered-recording-search-number').contains('検索結果 491 件中 1 〜 100件')
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
-      '上を向いて歩こう'
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 491 件中 1 〜 100件'
     )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
-      'トータス松本'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)'
+    ).contains('トータス松本')
 
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
 
     cy.get('.pagination').contains('>').click()
-    cy.get('.filtered-recording-search-number').contains('検索結果 491 件中 101 〜 200件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 491 件中 101 〜 200件'
+    )
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
 
     cy.get('.last-button').click()
-    cy.get('.filtered-recording-search-number').contains('検索結果 491 件中 401 〜 491件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 491 件中 401 〜 491件'
+    )
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '91 items').to.have.length(91)
     })
@@ -157,14 +167,16 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.filtered-recording-search-number').contains('検索結果 36 件中 1 〜 36件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 36 件中 1 〜 36件'
+    )
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
-      '上を向いて歩こう'
-    )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
-      '坂本九'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('坂本九')
 
     cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("坂本九")')
@@ -214,21 +226,25 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.filtered-recording-search-number').contains('検索結果 122 件中 1 〜 100件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 122 件中 1 〜 100件'
+    )
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
-      '上を向いて歩こう'
-    )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
-      'トータス松本'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)'
+    ).contains('トータス松本')
 
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
 
     cy.get('.pagination').contains('>').click()
-    cy.get('.filtered-recording-search-number').contains('検索結果 122 件中 101 〜 122件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 122 件中 101 〜 122件'
+    )
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '22 items').to.have.length(22)
     })
@@ -273,14 +289,16 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.filtered-recording-search-number').contains('検索結果 31 件中 1 〜 31件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 31 件中 1 〜 31件'
+    )
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
-      '上を向いて歩こう'
-    )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
-      '坂本九'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)'
+    ).contains('坂本九')
 
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '31 items').to.have.length(31)
@@ -328,14 +346,16 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.filtered-recording-search-number').contains('検索結果 35 件中 1 〜 35件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 35 件中 1 〜 35件'
+    )
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
-      '上を向いて歩こう'
-    )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
-      '坂本九'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)'
+    ).contains('坂本九')
 
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '35 items').to.have.length(35)
@@ -384,14 +404,16 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.filtered-recording-search-number').contains('検索結果 30 件中 1 〜 30件')
+    cy.get('.filtered-recording-search-number').contains(
+      '検索結果 30 件中 1 〜 30件'
+    )
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
-      '上を向いて歩こう'
-    )
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
-      '坂本九'
-    )
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)'
+    ).contains('上を向いて歩こう')
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)'
+    ).contains('坂本九')
 
     cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("坂本九")')
@@ -437,7 +459,9 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('.no-filtered-recording > p').contains('条件に該当する音源はありませんでした。')
+    cy.get('.no-filtered-recording > p').contains(
+      '条件に該当する音源はありませんでした。'
+    )
 
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '0 item').to.have.length(0)

--- a/cypress/component/RecordingSearchFilter.cy.ts
+++ b/cypress/component/RecordingSearchFilter.cy.ts
@@ -64,6 +64,7 @@ describe('RecordingSearchFilter tests', () => {
       .should(($trs) => {
         expect($trs, '24 items').to.have.length(24)
       })
+    cy.get('.pagination')
   })
 
   it('Only exclude inst', () => {
@@ -130,6 +131,7 @@ describe('RecordingSearchFilter tests', () => {
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '91 items').to.have.length(91)
     })
+    cy.get('.pagination')
   })
 
   it('Only artist filter', () => {
@@ -248,6 +250,7 @@ describe('RecordingSearchFilter tests', () => {
     cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '22 items').to.have.length(22)
     })
+    cy.get('.pagination')
   })
 
   it('Partial and artist filter', () => {

--- a/cypress/component/RecordingSearchFilter.cy.ts
+++ b/cypress/component/RecordingSearchFilter.cy.ts
@@ -37,40 +37,32 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue5Request')
 
     cy.get('h1').contains('絞り込み結果')
-    cy.get('p').contains('検索結果 124 件中 1 〜 100件')
+    cy.get('.filtered-recording-search-number').contains('検索結果 124 件中 1 〜 100件')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
       '長渕剛'
     )
 
-    //曲名が100件ちょうどあるか
-    cy.get('.table-auto > tbody > tr')
+    cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("上を向いて歩こう")')
       .should(($trs) => {
         expect($trs, '100 items').to.have.length(100)
       })
 
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div')
-    cy.get(':nth-child(3) > .paginate-buttons').contains('2')
-    cy.get(':nth-child(4) > .paginate-buttons').contains('>')
+    cy.get('.pagination').contains('2').click()
+    cy.get('.filtered-recording-search-number').contains('検索結果 124 件中 101 〜 124件')
 
-    //2ページ目
-    cy.get(':nth-child(3) > .paginate-buttons').contains('2').click()
-    cy.get('p').contains('検索結果 124 件中 101 〜 124件')
-
-    //曲名が24件ちょうどあるか
-    cy.get('.table-auto > tbody > tr')
+    cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("上を向いて歩こう")')
       .should(($trs) => {
         expect($trs, '24 items').to.have.length(24)
       })
   })
 
-  it('Only get rid of inst', () => {
+  it('Only exclude inst', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=0&limit=100&fmt=json',
@@ -105,35 +97,27 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('検索結果 491 件中 1 〜 100件')
-
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-number').contains('検索結果 491 件中 1 〜 100件')
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
       'トータス松本'
     )
 
-    //曲名が100件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
 
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div')
-    cy.get(':nth-child(3) > .paginate-buttons').contains('2')
-
-    //2ページ目
-    cy.get(':nth-child(7) > .paginate-buttons').contains('>').click()
-    cy.get('p').contains('検索結果 491 件中 101 〜 200件')
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.pagination').contains('>').click()
+    cy.get('.filtered-recording-search-number').contains('検索結果 491 件中 101 〜 200件')
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
 
-    //5ページ目
     cy.get('.last-button').click()
-    cy.get('p').contains('検索結果 491 件中 401 〜 491件')
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.filtered-recording-search-number').contains('検索結果 491 件中 401 〜 491件')
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '91 items').to.have.length(91)
     })
   })
@@ -173,27 +157,25 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('検索結果 36 件中 1 〜 36件')
+    cy.get('.filtered-recording-search-number').contains('検索結果 36 件中 1 〜 36件')
 
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(1) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains(
       '坂本九'
     )
 
-    //曲名が36件ちょうどあるか
-    cy.get('.table-auto > tbody > tr')
+    cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("坂本九")')
       .should(($trs) => {
         expect($trs, '36 items').to.have.length(36)
       })
 
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
-  it('Partial and get rid of inst', () => {
+  it('Partial and exclude inst', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=0&limit=100&fmt=json',
@@ -232,28 +214,22 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('検索結果 122 件中 1 〜 100件')
+    cy.get('.filtered-recording-search-number').contains('検索結果 122 件中 1 〜 100件')
 
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
       'トータス松本'
     )
 
-    //曲名が100件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '100 items').to.have.length(100)
     })
 
-    //ページネーションのコンポーネントが表示されているかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div')
-    cy.get(':nth-child(3) > .paginate-buttons').contains('2')
-
-    //2ページ目
-    cy.get(':nth-child(3) > .paginate-buttons').click()
-    cy.get('p').contains('検索結果 122 件中 101 〜 122件')
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.pagination').contains('>').click()
+    cy.get('.filtered-recording-search-number').contains('検索結果 122 件中 101 〜 122件')
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '22 items').to.have.length(22)
     })
   })
@@ -297,25 +273,23 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('検索結果 31 件中 1 〜 31件')
+    cy.get('.filtered-recording-search-number').contains('検索結果 31 件中 1 〜 31件')
 
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
       '坂本九'
     )
 
-    //曲名が35件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '31 items').to.have.length(31)
     })
 
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
-  it('Get rid of inst and artist filter', () => {
+  it('Exclude inst and artist filter', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=0&limit=100&fmt=json',
@@ -354,22 +328,20 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('検索結果 35 件中 1 〜 35件')
+    cy.get('.filtered-recording-search-number').contains('検索結果 35 件中 1 〜 35件')
 
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
       '坂本九'
     )
 
-    //曲名が35件ちょうどあるか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '35 items').to.have.length(35)
     })
 
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('All filter', () => {
@@ -412,28 +384,25 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('検索結果 30 件中 1 〜 30件')
+    cy.get('.filtered-recording-search-number').contains('検索結果 30 件中 1 〜 30件')
 
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(1)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(1)').contains(
       '上を向いて歩こう'
     )
-    cy.get('.table-auto > tbody > :nth-child(2) > :nth-child(2)').contains(
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(2) > :nth-child(2)').contains(
       '坂本九'
     )
 
-    //曲名が30件ちょうどあるか
-    cy.get('.table-auto > tbody > tr')
+    cy.get('.filtered-recording-search-table > tbody > tr')
       .filter(':contains("坂本九")')
       .should(($trs) => {
         expect($trs, '30 items').to.have.length(30)
       })
 
-    //ページネーションのコンポーネントが表示されていないかどうか
-    cy.get('[data-v-app=""] > :nth-child(1) > div').should('not.be')
+    cy.get('.pagination').should('not.be')
   })
 
   it('No result', () => {
-    //検索結果が0件
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=0&limit=100&fmt=json',
@@ -468,10 +437,9 @@ describe('RecordingSearchFilter tests', () => {
     cy.wait('@ue4Request')
     cy.wait('@ue5Request')
 
-    cy.get('p').contains('条件に該当する音源はありませんでした。')
+    cy.get('.no-filtered-recording > p').contains('条件に該当する音源はありませんでした。')
 
-    //1件も表示されていないか
-    cy.get('.table-auto > tbody > tr').should(($trs) => {
+    cy.get('.filtered-recording-search-table > tbody > tr').should(($trs) => {
       expect($trs, '0 item').to.have.length(0)
     })
   })

--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -13,7 +13,6 @@ describe('Artist search and lookup recordings', () => {
     cy.wait('@komurotetsuya1PageRequest')
     cy.contains('小室哲哉')
 
-    //小室哲哉をクリック
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/de242082-2f3e-4ce5-99e1-7839559da089?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
@@ -24,12 +23,11 @@ describe('Artist search and lookup recordings', () => {
       'https://musicbrainz.org/ws/2/recording?artist=de242082-2f3e-4ce5-99e1-7839559da089&offset=0&limit=100&fmt=json',
       { fixture: 'mock_komurotetsuya_recording_page1.json' }
     ).as('komurotetsuyaRecording1PageRequest')
-    cy.get(':nth-child(1) > .border > a').click()
+    cy.get(':nth-child(1) > .border > a').click() //検索結果の表の名前をつけた方が良いかも
     cy.wait('@komurotetsuyaRelationshipRequest')
     cy.wait('@komurotetsuyaRecording1PageRequest')
     cy.contains('小室哲哉')
 
-    //アーティスト音源の詳細へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/08cea5ad-09af-466a-b2f4-46ec63dd2d09?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels+isrcs&fmt=json',
@@ -45,10 +43,9 @@ describe('Artist search and lookup recordings', () => {
     cy.wait('@komurotetsuyaDWakareSpotifyRequest')
     cy.get('.text-2xl').contains('Dのテーマ (別れ)')
     cy.get('p.break-all').contains('小室哲哉')
-    cy.get(':nth-child(1) > :nth-child(6) > :nth-child(2) > a').should('not.be')
+    cy.get(':nth-child(1) > :nth-child(6) > :nth-child(2) > a').should('not.be') //spotifyのやつ
     cy.go('back')
 
-    //workへ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/work/73d884ae-bdb1-466f-8585-23aeb4644bfb?inc=recording-rels+artist-credits&fmt=json',
@@ -59,7 +56,6 @@ describe('Artist search and lookup recordings', () => {
     ).click()
     cy.wait('@komurotetsuyaCrazyWorkRequest')
 
-    //作詞作曲した曲へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/4f33f498-ecac-429a-87ee-ec6f74680fcc?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels+isrcs&fmt=json',
@@ -70,7 +66,7 @@ describe('Artist search and lookup recordings', () => {
       'https://api.spotify.com/v1/search?query=isrc%3AJPB609520101&type=track&offset=0&limit=20',
       { fixture: 'mock_crazy_spotify.json' }
     ).as('komurotetsuyaCrazySpotifyRequest')
-    cy.get(':nth-child(2) > .max-w-\\[600px\\] > a').click()
+    cy.get(':nth-child(2) > .max-w-\\[600px\\] > a').click() //workの表もわかりやすくした方がよさそう
     cy.wait('@komurotetsuyaCrazyRelationshipRequest')
     cy.wait('@komurotetsuyaCrazySpotifyRequest')
 
@@ -88,7 +84,6 @@ describe('Artist search and lookup recordings', () => {
     cy.go('back')
     cy.go('back')
 
-    //スタッフ曲へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/ff0a6f14-14b2-4b32-b84b-b6961293b92c?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels+isrcs&fmt=json',

--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -9,7 +9,7 @@ describe('Artist search and lookup recordings', () => {
 
     cy.get('[value="人物名"]').check()
     cy.get('#search').type('小室哲哉{enter}', { force: true })
-    cy.get('.text-white').click()
+    cy.get('.search-button').click()
     cy.wait('@komurotetsuya1PageRequest')
     cy.contains('小室哲哉')
 
@@ -146,7 +146,7 @@ describe('Artist search and lookup recordings', () => {
 
     cy.get('[value="人物名"]').check()
     cy.get('#search').type('小室哲哉{enter}', { force: true })
-    cy.get('.text-white').click()
+    cy.get('.search-button').click()
     cy.wait('@komurotetsuya1PageRequest')
     cy.contains('小室哲哉')
 

--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -43,7 +43,7 @@ describe('Artist search and lookup recordings', () => {
     cy.wait('@komurotetsuyaDWakareSpotifyRequest')
     cy.get('.text-2xl').contains('Dのテーマ (別れ)')
     cy.get('p.break-all').contains('小室哲哉')
-    cy.get(':nth-child(1) > :nth-child(6) > :nth-child(2) > a').should('not.be') //spotifyのやつ
+    cy.get('.spotify-button').should('be.disabled')
     cy.go('back')
 
     cy.intercept(
@@ -66,7 +66,7 @@ describe('Artist search and lookup recordings', () => {
       'https://api.spotify.com/v1/search?query=isrc%3AJPB609520101&type=track&offset=0&limit=20',
       { fixture: 'mock_crazy_spotify.json' }
     ).as('komurotetsuyaCrazySpotifyRequest')
-    cy.get(':nth-child(2) > .max-w-\\[600px\\] > a').click() //workの表もわかりやすくした方がよさそう
+    cy.get('.work-table > tbody > :nth-child(2) > :nth-child(1) > a').click()
     cy.wait('@komurotetsuyaCrazyRelationshipRequest')
     cy.wait('@komurotetsuyaCrazySpotifyRequest')
 
@@ -76,7 +76,7 @@ describe('Artist search and lookup recordings', () => {
       .parent()
       .parent()
       .contains('小室哲哉')
-    cy.get('.bg-blue-400 > a').should(
+    cy.get('.spotify-button > a').should(
       'have.attr',
       'href',
       'https://open.spotify.com/track/40zhzdBp94MQDk5uRf4NDR'
@@ -103,7 +103,7 @@ describe('Artist search and lookup recordings', () => {
       .parent()
       .parent()
       .contains('小室哲哉')
-    cy.get('.bg-blue-400').should('be.disabled')
+    cy.get('.spotify-button').should('be.disabled')
     cy.go('back')
   })
 
@@ -155,10 +155,10 @@ describe('Artist search and lookup recordings', () => {
       'https://musicbrainz.org/ws/2/artist/?query=artist:%E5%B0%8F%E5%AE%A4%E5%93%B2%E5%93%89&offset=100&limit=100&fmt=json',
       { fixture: 'mock_komurotetsuya_page2.json' }
     ).as('komurotetsuya2PageRequest')
-    cy.get(':nth-child(7) > .paginate-buttons').click()
+    cy.get('.pagination').contains('>').click()
     cy.wait('@komurotetsuya2PageRequest')
     cy.get('body').should('not.contain', 'Undefined')
-    cy.get('.back-button').click()
+    cy.get('.pagination').contains('<').click()
   })
 })
 export {}

--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -23,7 +23,7 @@ describe('Artist search and lookup recordings', () => {
       'https://musicbrainz.org/ws/2/recording?artist=de242082-2f3e-4ce5-99e1-7839559da089&offset=0&limit=100&fmt=json',
       { fixture: 'mock_komurotetsuya_recording_page1.json' }
     ).as('komurotetsuyaRecording1PageRequest')
-    cy.get(':nth-child(1) > .border > a').click() //検索結果の表の名前をつけた方が良いかも
+    cy.get('.artist-search-table > tbody > :nth-child(1) > td > a').click()
     cy.wait('@komurotetsuyaRelationshipRequest')
     cy.wait('@komurotetsuyaRecording1PageRequest')
     cy.contains('小室哲哉')

--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -11,7 +11,7 @@ describe('Artist search and lookup recordings', () => {
     cy.get('#search').type('小室哲哉{enter}', { force: true })
     cy.get('.search-button').click()
     cy.wait('@komurotetsuya1PageRequest')
-    cy.contains('小室哲哉')
+    cy.get('.artist-search-table > tbody').contains('小室哲哉')
 
     cy.intercept(
       'GET',
@@ -41,8 +41,8 @@ describe('Artist search and lookup recordings', () => {
     cy.get('.artist-table > tbody > :nth-child(1) > td > a ').click()
     cy.wait('@komurotetsuyaDWakareRelationshipRequest')
     cy.wait('@komurotetsuyaDWakareSpotifyRequest')
-    cy.get('.text-2xl').contains('Dのテーマ (別れ)')
-    cy.get('p.break-all').contains('小室哲哉')
+    cy.get('.recording-title').contains('Dのテーマ (別れ)')
+    cy.get('.artist-name').contains('小室哲哉')
     cy.get('.spotify-button').should('be.disabled')
     cy.go('back')
 
@@ -70,8 +70,8 @@ describe('Artist search and lookup recordings', () => {
     cy.wait('@komurotetsuyaCrazyRelationshipRequest')
     cy.wait('@komurotetsuyaCrazySpotifyRequest')
 
-    cy.get('.text-2xl').contains('CRAZY GONNA CRAZY')
-    cy.get('table tbody tr')
+    cy.get('.recording-title').contains('CRAZY GONNA CRAZY')
+    cy.get('.songwriter-data > tr')
       .contains('composer')
       .parent()
       .parent()
@@ -97,8 +97,8 @@ describe('Artist search and lookup recordings', () => {
     cy.get('.staff-table > tbody > :nth-child(1) > :nth-child(2) > a').click()
     cy.wait('@komurotetsuyaSoon19RelationshipRequest')
     cy.wait('@komurotetsuyaSoon19SpotifyRequest')
-    cy.get('.text-2xl').contains('...soon nineteen')
-    cy.get('table tbody tr')
+    cy.get('.recording-title').contains('...soon nineteen')
+    cy.get('.staff-data > tr')
       .contains('arranger')
       .parent()
       .parent()
@@ -119,7 +119,7 @@ describe('Artist search and lookup recordings', () => {
     cy.get('#search').type('YOASOBI{enter}', { force: true })
     cy.get('.search-button').click()
     cy.wait('@yoasobiRequest')
-    cy.contains('YOASOBI')
+    cy.get('.artist-search-table > tbody').contains('YOASOBI')
 
     cy.intercept(
       'GET',
@@ -132,7 +132,7 @@ describe('Artist search and lookup recordings', () => {
       .type('the band apart{enter}', { force: true })
     cy.get('.search-button').first().click()
     cy.wait('@theBandApartRequest')
-    cy.contains('the band apart')
+    cy.get('.artist-search-table > tbody').contains('the band apart')
   })
 
   it('Check search word is not undefined by using pagination', () => {
@@ -148,7 +148,7 @@ describe('Artist search and lookup recordings', () => {
     cy.get('#search').type('小室哲哉{enter}', { force: true })
     cy.get('.search-button').click()
     cy.wait('@komurotetsuya1PageRequest')
-    cy.contains('小室哲哉')
+    cy.get('.artist-search-table > tbody').contains('小室哲哉')
 
     cy.intercept(
       'GET',

--- a/cypress/e2e/flow_artist_search.spec.cy.ts
+++ b/cypress/e2e/flow_artist_search.spec.cy.ts
@@ -117,7 +117,7 @@ describe('Artist search and lookup recordings', () => {
     ).as('yoasobiRequest')
     cy.get('[value="人物名"]').check()
     cy.get('#search').type('YOASOBI{enter}', { force: true })
-    cy.contains('検索').click()
+    cy.get('.search-button').click()
     cy.wait('@yoasobiRequest')
     cy.contains('YOASOBI')
 
@@ -130,7 +130,7 @@ describe('Artist search and lookup recordings', () => {
       .focus()
       .clear()
       .type('the band apart{enter}', { force: true })
-    cy.contains('検索').first().click()
+    cy.get('.search-button').first().click()
     cy.wait('@theBandApartRequest')
     cy.contains('the band apart')
   })

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -39,7 +39,7 @@ describe('Recording search and lookup artist', () => {
       'href',
       'https://open.spotify.com/track/0jpP8AlQLVtaMwA3vQYpYB'
     )
-    cy.get('.pagination').should('not.be')
+    cy.get('.no-spotify').should('not.be')
 
     cy.intercept(
       'GET',
@@ -351,7 +351,6 @@ describe('Recording search and lookup artist', () => {
       'not.contain',
       'Undefined'
     )
-    cy.get('.pagination').contains('<').click()
   })
 })
 export {}

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -9,7 +9,7 @@ describe('Recording search and lookup artist', () => {
     cy.get('input[type="search"]')
       .should('be.visible')
       .type('青春コンプレックス', { force: true })
-    cy.get('button[type="submit"]').click()
+    cy.get('.search-button').click()
     cy.wait('@seisyun1PageRequest')
     cy.get('.recording-search-table > tbody').contains('青春コンプレックス')
     cy.get('.recording-search-table > tbody').contains('結束バンド')
@@ -306,7 +306,7 @@ describe('Recording search and lookup artist', () => {
     cy.get('input[type="search"]')
       .should('be.visible')
       .type('青春コンプレックス', { force: true })
-    cy.get('button[type="submit"]').click()
+    cy.get('.search-button').click()
     cy.wait('@seisyun1PageRequest')
 
     cy.intercept(

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -14,7 +14,6 @@ describe('Recording search and lookup artist', () => {
     cy.contains('青春コンプレックス')
     cy.contains('結束バンド')
 
-    //音源詳細へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/7c8ca692-d78a-4785-a7f4-7cc9ed0fb0f5?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels+isrcs&fmt=json',
@@ -38,9 +37,8 @@ describe('Recording search and lookup artist', () => {
       'href',
       'https://open.spotify.com/track/0jpP8AlQLVtaMwA3vQYpYB'
     )
-    cy.get('.my-2 > p').should('not.be')
+    cy.get('.pagination').should('not.be')
 
-    //アーティスト詳細へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/c1b0fe0a-779d-43ed-b193-4370f0d0f88f?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
@@ -58,7 +56,6 @@ describe('Recording search and lookup artist', () => {
     cy.contains('青春コンプレックス')
     cy.go('back')
 
-    //作詞作曲者詳細へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/779f1dee-35ca-4b75-8db5-9ae3ce3b16c8?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
@@ -79,7 +76,6 @@ describe('Recording search and lookup artist', () => {
       .contains('composer')
     cy.go('back')
 
-    //スタッフ詳細へ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/66dea38d-e16d-4774-b5c5-e0ee56808731?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
@@ -101,7 +97,6 @@ describe('Recording search and lookup artist', () => {
     cy.go('back')
     cy.go('back')
 
-    // Spotifyがない曲へ
     cy.get('#search').focus().clear()
     cy.intercept(
       'GET',
@@ -127,7 +122,7 @@ describe('Recording search and lookup artist', () => {
     cy.contains('Butter Sugar Cream (instrumental)').click()
     cy.wait('@butterSugarCreamRequest')
     cy.wait('@butterSugarCreamSpotifyRequest')
-    cy.get('.bg-blue-400').should('be.disabled')
+    cy.get('.bg-blue-400').should('be.disabled') //spotifyボタンを明確に指定すべし
     cy.get('.my-2 > p').contains('登録されているSpotifyでの音源情報がないため再生ができません。')
   })
 
@@ -143,7 +138,6 @@ describe('Recording search and lookup artist', () => {
     cy.wait('@resultTentaikansokuRequest')
     cy.contains('天体観測')
 
-    //フィルター1(インスト音源除外フィルター)のみ
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E5%A4%A9%E4%BD%93%E8%A6%B3%E6%B8%AC&offset=0&limit=100&fmt=json',
@@ -169,11 +163,8 @@ describe('Recording search and lookup artist', () => {
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E5%A4%A9%E4%BD%93%E8%A6%B3%E6%B8%AC&offset=400&limit=100&fmt=json',
       { fixture: 'mock_tentaikansoku5.json' }
     ).as('tentaikansoku5Request')
-
-    //フィルターに何も設定しないとき「適用」がdisableになっているか
     cy.get('#apply').should('be.disabled')
 
-    //フィルター1(インスト音源除外フィルター)のみ
     cy.get('#inst').check()
     cy.get('#apply').click()
     cy.wait('@tentaikansoku1Request')
@@ -188,32 +179,26 @@ describe('Recording search and lookup artist', () => {
     )
     cy.go('back')
 
-    //フィルター2(部分一致フィルター)のみ
     cy.get('#filter').clear()
     cy.get('#partial').check()
     cy.get('#apply').click()
-
     cy.contains('天体観測')
     cy.get('tbody').should('not.contain', 'スカイクラッドの観測者')
     cy.go('back')
 
-    //フィルター3(アーティスト名フィルター)のみ
     cy.get('#filter').clear()
     cy.get('#filter').type('BUMP OF CHICKEN')
     cy.get('#apply').click()
-
     cy.get('tbody > :nth-child(1) > :nth-child(2)').contains('BUMP OF CHICKEN')
     cy.get('.table-auto tbody tr td:nth-child(2)').each(($td) => {
       expect($td.text()).not.to.include('入尾信充')
     })
     cy.go('back')
 
-    //フィルター1と2
     cy.get('#filter').clear()
     cy.get('#inst').check()
     cy.get('#partial').check()
     cy.get('#apply').click()
-
     cy.contains('真夏の天体観測')
     cy.get('tbody').should('not.contain', 'スカイクラッドの観測者')
     cy.get('tbody').should('not.contain', '真夏の天体観測 ～Instrumental～')
@@ -230,7 +215,6 @@ describe('Recording search and lookup artist', () => {
     cy.wait('@resultCelebrateRequest')
     cy.contains('CAN YOU CELEBRATE?')
 
-    //フィルター1と3
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:can%20you%20celebrate&offset=0&limit=100&fmt=json',
@@ -276,7 +260,6 @@ describe('Recording search and lookup artist', () => {
     cy.get('tbody').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
     cy.go('back')
 
-    //フィルター2と3
     cy.get('#filter').clear()
     cy.get('#partial').check()
     cy.get('#filter').type('安室奈美恵')
@@ -294,7 +277,6 @@ describe('Recording search and lookup artist', () => {
     )
     cy.go('back')
 
-    //フィルター1と2と3
     cy.get('#filter').clear()
     cy.get('#inst').check()
     cy.get('#partial').check()
@@ -332,10 +314,10 @@ describe('Recording search and lookup artist', () => {
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E9%9D%92%E6%98%A5%E3%82%B3%E3%83%B3%E3%83%97%E3%83%AC%E3%83%83%E3%82%AF%E3%82%B9&offset=100&limit=100&fmt=json',
       { fixture: 'mock_seisyun_page2.json' }
     ).as('seisyun2PageRequest')
-    cy.get(':nth-child(7) > .paginate-buttons').click()
+    cy.get('.pagination').contains('>').click()
     cy.wait('@seisyun2PageRequest')
     cy.get('body').should('not.contain', 'Undefined')
-    cy.get('.back-button').click()
+    cy.get('.pagination').contains('<').click()
   })
 })
 export {}

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -122,8 +122,8 @@ describe('Recording search and lookup artist', () => {
     cy.contains('Butter Sugar Cream (instrumental)').click()
     cy.wait('@butterSugarCreamRequest')
     cy.wait('@butterSugarCreamSpotifyRequest')
-    cy.get('.bg-blue-400').should('be.disabled') //spotifyボタンを明確に指定すべし
-    cy.get('.my-2 > p').contains('登録されているSpotifyでの音源情報がないため再生ができません。')
+    cy.get('.spotify-button').should('be.disabled')
+    cy.get('.no-spotify > p').contains('登録されているSpotifyでの音源情報がないため再生ができません。')
   })
 
   it('apply filter', () => {

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -24,7 +24,9 @@ describe('Recording search and lookup artist', () => {
       'https://api.spotify.com/v1/search?query=isrc%3AJPE302200934&type=track&offset=0&limit=20',
       { fixture: 'mock_seisyun_spotify.json' }
     ).as('seisyunSpotifyRequest')
-    cy.get('.recording-search-table > tbody > :nth-child(1) > td').contains('青春コンプレックス').click()
+    cy.get('.recording-search-table > tbody > :nth-child(1) > td')
+      .contains('青春コンプレックス')
+      .click()
     cy.wait('@seisyunRelationshipRequest')
     cy.wait('@seisyunSpotifyRequest')
     cy.url().should(
@@ -123,7 +125,9 @@ describe('Recording search and lookup artist', () => {
     cy.wait('@butterSugarCreamRequest')
     cy.wait('@butterSugarCreamSpotifyRequest')
     cy.get('.spotify-button').should('be.disabled')
-    cy.get('.no-spotify > p').contains('登録されているSpotifyでの音源情報がないため再生ができません。')
+    cy.get('.no-spotify > p').contains(
+      '登録されているSpotifyでの音源情報がないため再生ができません。'
+    )
   })
 
   it('apply filter', () => {
@@ -183,7 +187,10 @@ describe('Recording search and lookup artist', () => {
     cy.get('#partial').check()
     cy.get('#apply').click()
     cy.contains('天体観測')
-    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', 'スカイクラッドの観測者')
+    cy.get('.filtered-recording-search-table > tbody > tr').should(
+      'not.contain',
+      'スカイクラッドの観測者'
+    )
     cy.go('back')
 
     cy.get('#filter').clear()
@@ -200,8 +207,14 @@ describe('Recording search and lookup artist', () => {
     cy.get('#partial').check()
     cy.get('#apply').click()
     cy.contains('真夏の天体観測')
-    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', 'スカイクラッドの観測者')
-    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', '真夏の天体観測 ～Instrumental～')
+    cy.get('.filtered-recording-search-table > tbody > tr').should(
+      'not.contain',
+      'スカイクラッドの観測者'
+    )
+    cy.get('.filtered-recording-search-table > tbody > tr').should(
+      'not.contain',
+      '真夏の天体観測 ～Instrumental～'
+    )
 
     //検索音源変更
     cy.intercept(
@@ -251,13 +264,20 @@ describe('Recording search and lookup artist', () => {
     cy.wait('@celebrate4Request')
     cy.wait('@celebrate5Request')
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
-    cy.get('.filtered-recording-search-table > tbody > tr > td:nth-child(2)').each(($td) => {
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('安室奈美恵')
+    cy.get(
+      '.filtered-recording-search-table > tbody > tr > td:nth-child(2)'
+    ).each(($td) => {
       expect($td.text()).not.to.include('白鳥英美子')
     })
     cy.contains('CAN YOU CELEBRATE?')
     cy.contains('Dreaming I was dreaming (Subconscious mix)')
-    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
+    cy.get('.filtered-recording-search-table > tbody > tr').should(
+      'not.contain',
+      'CAN YOU CELEBRATE? (instrumental)'
+    )
     cy.go('back')
 
     cy.get('#filter').clear()
@@ -265,8 +285,12 @@ describe('Recording search and lookup artist', () => {
     cy.get('#filter').type('安室奈美恵')
     cy.get('#apply').click()
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
-    cy.get('.filtered-recording-search-table > tbody > tr > td:nth-child(2)').each(($td) => {
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('安室奈美恵')
+    cy.get(
+      '.filtered-recording-search-table > tbody > tr > td:nth-child(2)'
+    ).each(($td) => {
       expect($td.text()).not.to.include('白鳥英美子')
     })
     cy.contains('CAN YOU CELEBRATE?')
@@ -283,12 +307,19 @@ describe('Recording search and lookup artist', () => {
     cy.get('#filter').type('安室奈美恵')
     cy.get('#apply').click()
 
-    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
-    cy.get('.filtered-recording-search-table > tbody > tr > td:nth-child(2)').each(($td) => {
+    cy.get(
+      '.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)'
+    ).contains('安室奈美恵')
+    cy.get(
+      '.filtered-recording-search-table > tbody > tr > td:nth-child(2)'
+    ).each(($td) => {
       expect($td.text()).not.to.include('白鳥英美子')
     })
     cy.contains('CAN YOU CELEBRATE?')
-    cy.get('.filtered-recording-search-table > tbody').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
+    cy.get('.filtered-recording-search-table > tbody').should(
+      'not.contain',
+      'CAN YOU CELEBRATE? (instrumental)'
+    )
     cy.get('.filtered-recording-search-table > tbody').should(
       'not.contain',
       'Dreaming I was dreaming (Subconscious mix)'
@@ -316,7 +347,10 @@ describe('Recording search and lookup artist', () => {
     ).as('seisyun2PageRequest')
     cy.get('.pagination').contains('>').click()
     cy.wait('@seisyun2PageRequest')
-    cy.get('.recording-search-table > tbody > tr').should('not.contain', 'Undefined')
+    cy.get('.recording-search-table > tbody > tr').should(
+      'not.contain',
+      'Undefined'
+    )
     cy.get('.pagination').contains('<').click()
   })
 })

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -32,7 +32,7 @@ describe('Recording search and lookup artist', () => {
       '/recordings/7c8ca692-d78a-4785-a7f4-7cc9ed0fb0f5'
     )
     cy.contains('青春コンプレックス')
-    cy.get('.bg-blue-400 > a').should(
+    cy.get('.spotify-button > a').should(
       'have.attr',
       'href',
       'https://open.spotify.com/track/0jpP8AlQLVtaMwA3vQYpYB'

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -106,7 +106,7 @@ describe('Recording search and lookup artist', () => {
     cy.get('#search').type('Butter Sugar Cream (instrumental){enter}', {
       force: true,
     })
-    cy.contains('検索').click()
+    cy.get('.search-button').click()
     cy.wait('@butterSugarCreamSearchRequest')
 
     cy.intercept(
@@ -134,7 +134,7 @@ describe('Recording search and lookup artist', () => {
       { fixture: 'mock_result_tentaikansoku.json' }
     ).as('resultTentaikansokuRequest')
     cy.get('#search').type('天体観測{enter}', { force: true })
-    cy.contains('検索').click()
+    cy.get('.search-button').click()
     cy.wait('@resultTentaikansokuRequest')
     cy.contains('天体観測')
 
@@ -211,7 +211,7 @@ describe('Recording search and lookup artist', () => {
     ).as('resultCelebrateRequest')
     cy.get('#search').focus().clear()
     cy.get('#search').type('can you celebrate{enter}', { force: true })
-    cy.contains('検索').click()
+    cy.get('.search-button').click()
     cy.wait('@resultCelebrateRequest')
     cy.contains('CAN YOU CELEBRATE?')
 

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -11,8 +11,8 @@ describe('Recording search and lookup artist', () => {
       .type('青春コンプレックス', { force: true })
     cy.get('button[type="submit"]').click()
     cy.wait('@seisyun1PageRequest')
-    cy.contains('青春コンプレックス')
-    cy.contains('結束バンド')
+    cy.get('.recording-search-table > tbody').contains('青春コンプレックス')
+    cy.get('.recording-search-table > tbody').contains('結束バンド')
 
     cy.intercept(
       'GET',
@@ -24,7 +24,7 @@ describe('Recording search and lookup artist', () => {
       'https://api.spotify.com/v1/search?query=isrc%3AJPE302200934&type=track&offset=0&limit=20',
       { fixture: 'mock_seisyun_spotify.json' }
     ).as('seisyunSpotifyRequest')
-    cy.contains('青春コンプレックス').click()
+    cy.get('.recording-search-table > tbody > :nth-child(1) > td').contains('青春コンプレックス').click()
     cy.wait('@seisyunRelationshipRequest')
     cy.wait('@seisyunSpotifyRequest')
     cy.url().should(
@@ -49,11 +49,11 @@ describe('Recording search and lookup artist', () => {
       'https://musicbrainz.org/ws/2/recording?artist=c1b0fe0a-779d-43ed-b193-4370f0d0f88f&offset=0&limit=100&fmt=json',
       { fixture: 'mock_kessoku_recording.json' }
     ).as('kessokuRecordingRequest')
-    cy.get('p.break-all > span > a').click()
+    cy.get('p.artist-name > span > a').click()
     cy.wait('@kessokuRelationshipRequest')
     cy.wait('@kessokuRecordingRequest')
-    cy.contains('結束バンド')
-    cy.contains('青春コンプレックス')
+    cy.get('.artist-name').contains('結束バンド')
+    cy.get('.artist-table > tbody').contains('青春コンプレックス')
     cy.go('back')
 
     cy.intercept(
@@ -66,10 +66,10 @@ describe('Recording search and lookup artist', () => {
       'https://musicbrainz.org/ws/2/recording?artist=779f1dee-35ca-4b75-8db5-9ae3ce3b16c8&offset=0&limit=100&fmt=json',
       { fixture: 'mock_otoha_recording.json' }
     ).as('otohaRecordingRequest')
-    cy.contains('音羽-otoha-').click()
+    cy.get('.songwriter-data').contains('音羽-otoha-').click()
     cy.wait('@otohaRelationshipRequest')
     cy.wait('@otohaRecordingRequest')
-    cy.get('table tbody tr')
+    cy.get('.songwriter-table > tbody > tr')
       .contains('青春コンプレックス')
       .parent()
       .parent()
@@ -86,10 +86,10 @@ describe('Recording search and lookup artist', () => {
       'https://musicbrainz.org/ws/2/recording?artist=66dea38d-e16d-4774-b5c5-e0ee56808731&offset=0&limit=100&fmt=json',
       { fixture: 'mock_mitsui_recording.json' }
     ).as('mitsuiRecordingRequest')
-    cy.contains('三井律郎').click()
+    cy.get('.staff-data').contains('三井律郎').click()
     cy.wait('@mitsuiRelationshipRequest')
     cy.wait('@mitsuiRecordingRequest')
-    cy.get('table tbody tr')
+    cy.get('.staff-table > tbody > tr')
       .contains('青春コンプレックス')
       .parent()
       .parent()
@@ -173,7 +173,7 @@ describe('Recording search and lookup artist', () => {
     cy.wait('@tentaikansoku4Request')
     cy.wait('@tentaikansoku5Request')
     cy.contains('天体観測')
-    cy.get('table tbody tr').should(
+    cy.get('.filtered-recording-search-table > tbody > tr').should(
       'not.contain',
       '天体観測(Instrumental Version)'
     )
@@ -183,7 +183,7 @@ describe('Recording search and lookup artist', () => {
     cy.get('#partial').check()
     cy.get('#apply').click()
     cy.contains('天体観測')
-    cy.get('tbody').should('not.contain', 'スカイクラッドの観測者')
+    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', 'スカイクラッドの観測者')
     cy.go('back')
 
     cy.get('#filter').clear()
@@ -200,8 +200,8 @@ describe('Recording search and lookup artist', () => {
     cy.get('#partial').check()
     cy.get('#apply').click()
     cy.contains('真夏の天体観測')
-    cy.get('tbody').should('not.contain', 'スカイクラッドの観測者')
-    cy.get('tbody').should('not.contain', '真夏の天体観測 ～Instrumental～')
+    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', 'スカイクラッドの観測者')
+    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', '真夏の天体観測 ～Instrumental～')
 
     //検索音源変更
     cy.intercept(
@@ -251,13 +251,13 @@ describe('Recording search and lookup artist', () => {
     cy.wait('@celebrate4Request')
     cy.wait('@celebrate5Request')
 
-    cy.get('tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
-    cy.get('.table-auto tbody tr td:nth-child(2)').each(($td) => {
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
+    cy.get('.filtered-recording-search-table > tbody > tr > td:nth-child(2)').each(($td) => {
       expect($td.text()).not.to.include('白鳥英美子')
     })
     cy.contains('CAN YOU CELEBRATE?')
     cy.contains('Dreaming I was dreaming (Subconscious mix)')
-    cy.get('tbody').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
+    cy.get('.filtered-recording-search-table > tbody > tr').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
     cy.go('back')
 
     cy.get('#filter').clear()
@@ -265,8 +265,8 @@ describe('Recording search and lookup artist', () => {
     cy.get('#filter').type('安室奈美恵')
     cy.get('#apply').click()
 
-    cy.get('tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
-    cy.get('.table-auto tbody tr td:nth-child(2)').each(($td) => {
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
+    cy.get('.filtered-recording-search-table > tbody > tr > td:nth-child(2)').each(($td) => {
       expect($td.text()).not.to.include('白鳥英美子')
     })
     cy.contains('CAN YOU CELEBRATE?')
@@ -283,13 +283,13 @@ describe('Recording search and lookup artist', () => {
     cy.get('#filter').type('安室奈美恵')
     cy.get('#apply').click()
 
-    cy.get('tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
-    cy.get('.table-auto tbody tr td:nth-child(2)').each(($td) => {
+    cy.get('.filtered-recording-search-table > tbody > :nth-child(1) > :nth-child(2)').contains('安室奈美恵')
+    cy.get('.filtered-recording-search-table > tbody > tr > td:nth-child(2)').each(($td) => {
       expect($td.text()).not.to.include('白鳥英美子')
     })
     cy.contains('CAN YOU CELEBRATE?')
-    cy.get('tbody').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
-    cy.get('tbody').should(
+    cy.get('.filtered-recording-search-table > tbody').should('not.contain', 'CAN YOU CELEBRATE? (instrumental)')
+    cy.get('.filtered-recording-search-table > tbody').should(
       'not.contain',
       'Dreaming I was dreaming (Subconscious mix)'
     )
@@ -316,7 +316,7 @@ describe('Recording search and lookup artist', () => {
     ).as('seisyun2PageRequest')
     cy.get('.pagination').contains('>').click()
     cy.wait('@seisyun2PageRequest')
-    cy.get('body').should('not.contain', 'Undefined')
+    cy.get('.recording-search-table > tbody > tr').should('not.contain', 'Undefined')
     cy.get('.pagination').contains('<').click()
   })
 })

--- a/src/components/NoResults.vue
+++ b/src/components/NoResults.vue
@@ -1,7 +1,9 @@
 <template>
-  <h1 class="text-2xl my-4 max-w-xl">Not Found!</h1>
-  <p>
-    見つかりませんでした。<br />
-    条件を変更して再度検索を行なってください。
-  </p>
+  <div class="no-result">
+    <h1 class="no-result-caption text-2xl my-4 max-w-xl">Not Found!</h1>
+    <p>
+      見つかりませんでした。<br />
+      条件を変更して再度検索を行なってください。
+    </p>
+  </div>
 </template>

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -1,7 +1,9 @@
 <template>
-  <h1 class="text-2xl my-4 max-w-xl">Not Found!</h1>
-  <p>アクセスしたページが見つかりません。</p>
-  <p>以下の理由が考えられます。</p>
-  <li>入力したURLに誤りがある</li>
-  <li>一時的なエラー</li>
+  <div class="not-found">
+    <h1 class="not-found-caption text-2xl my-4 max-w-xl">Not Found!</h1>
+    <p>アクセスしたページが見つかりません。</p>
+    <p>以下の理由が考えられます。</p>
+    <li>入力したURLに誤りがある</li>
+    <li>一時的なエラー</li>
+  </div>
 </template>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -53,7 +53,7 @@ const search = (): void => {
         </div>
         <button
           type="submit"
-          class="text-white absolute right-0 md:right-1.5 bottom-0 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2"
+          class="search-button text-white absolute right-0 md:right-1.5 bottom-0 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2"
         >
           検索
         </button>

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -96,7 +96,7 @@ const onClickHandler = async (page: number) => {
     </h1>
 
     <div v-if="refArtistData?.credit.song.length !== 0">
-      <p class="text-xl my-4 border-l-8 border-indigo-200 pl-2">
+      <p class="songwriter-caption text-xl my-4 border-l-8 border-indigo-200 pl-2">
         作詞作曲した音源
       </p>
       <table class="songwriter-table table-auto my-4">
@@ -139,7 +139,7 @@ const onClickHandler = async (page: number) => {
     <br />
 
     <div v-if="refArtistData?.credit.recording.length !== 0">
-      <p class="text-xl my-4 border-l-8 border-indigo-200 pl-2">
+      <p class="staff-caption text-xl my-4 border-l-8 border-indigo-200 pl-2">
         スタッフとして関わった音源
       </p>
       <table class="staff-table table-auto my-4">
@@ -182,10 +182,10 @@ const onClickHandler = async (page: number) => {
 
     <br />
     <div v-if="refArtistRecording?.length !== 0">
-      <p class="text-xl my-4 border-l-8 border-indigo-200 pl-2">
+      <p class="artist-caption text-xl my-4 border-l-8 border-indigo-200 pl-2">
         アーティストとして関わった音源
       </p>
-      <p>
+      <p class="artist-recording-number">
         {{
           totalItems +
           ' 件中 ' +

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -96,7 +96,9 @@ const onClickHandler = async (page: number) => {
     </h1>
 
     <div v-if="refArtistData?.credit.song.length !== 0">
-      <p class="songwriter-caption text-xl my-4 border-l-8 border-indigo-200 pl-2">
+      <p
+        class="songwriter-caption text-xl my-4 border-l-8 border-indigo-200 pl-2"
+      >
         作詞作曲した音源
       </p>
       <table class="songwriter-table table-auto my-4">

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -217,7 +217,7 @@ const onClickHandler = async (page: number) => {
         </tbody>
       </table>
     </div>
-    <div v-if="totalItems > 100">
+    <div v-if="totalItems > 100" class="pagination">
       <vue-awesome-paginate
         v-model="currentPage"
         :total-items="totalItems"

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -91,7 +91,7 @@ const onClickHandler = async (page: number) => {
     <NowLoading />
   </div>
   <div v-else-if="refArtistData || refArtistRecording">
-    <h1 class="text-2xl my-4 max-w-xl break-all">
+    <h1 class="artist-name text-2xl my-4 max-w-xl break-all">
       {{ refArtistData?.name }}
     </h1>
 

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -59,7 +59,7 @@ onMounted(() => {
   </div>
   <div v-else-if="refArtistData.length !== 0">
     <h1 class="text-2xl my-4 max-w-xl">人物検索結果</h1>
-    <p>
+    <p class="artist-search-number">
       {{
         '検索結果 ' +
         totalItems +

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -88,7 +88,7 @@ onMounted(() => {
         </tr>
       </tbody>
     </table>
-    <div v-if="totalItems > 100">
+    <div v-if="totalItems > 100" class="pagination">
       <vue-awesome-paginate
         v-model="currentPage"
         :total-items="totalItems"

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -70,7 +70,7 @@ onMounted(() => {
         '件'
       }}
     </p>
-    <table class="table-auto my-4 max-w-xl">
+    <table class="artist-search-table table-auto my-4 max-w-xl">
       <thead>
         <tr>
           <th class="px-4 py-2 border bg-blue-100 break-all">人物名</th>

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -141,10 +141,10 @@ onMounted(async () => {
     <NowLoading />
   </div>
   <div v-else-if="refRecordingData">
-    <h1 class="text-2xl my-4 max-w-xl break-all">
+    <h1 class="recording-title text-2xl my-4 max-w-xl break-all">
       {{ refRecordingData?.title }}
     </h1>
-    <p class="break-all">
+    <p class="artist-name break-all">
       アーティスト:
       <span
         v-for="artist in refRecordingData.credit.artistCredit"
@@ -187,7 +187,7 @@ onMounted(async () => {
             </th>
           </tr>
         </thead>
-        <tbody v-if="refRecordingData.credit.songWriterCredit">
+        <tbody v-if="refRecordingData.credit.songWriterCredit" class="songwriter-data">
           <tr
             v-for="songWriter in refRecordingData.credit.songWriterCredit"
             :key="songWriter.id"
@@ -207,7 +207,7 @@ onMounted(async () => {
             </td>
           </tr>
         </tbody>
-        <tbody v-if="refRecordingData.credit.staffCredit">
+        <tbody v-if="refRecordingData.credit.staffCredit" class="staff-data">
           <tr
             v-for="staff in refRecordingData.credit.staffCredit"
             :key="staff.id"
@@ -224,7 +224,7 @@ onMounted(async () => {
             </td>
           </tr>
         </tbody>
-        <tbody v-if="refRecordingData.credit.playerCredit">
+        <tbody v-if="refRecordingData.credit.playerCredit" class="player-data">
           <tr
             v-for="player in refRecordingData.credit.playerCredit"
             :key="player.id"

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -187,7 +187,10 @@ onMounted(async () => {
             </th>
           </tr>
         </thead>
-        <tbody v-if="refRecordingData.credit.songWriterCredit" class="songwriter-data">
+        <tbody
+          v-if="refRecordingData.credit.songWriterCredit"
+          class="songwriter-data"
+        >
           <tr
             v-for="songWriter in refRecordingData.credit.songWriterCredit"
             :key="songWriter.id"

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -244,7 +244,7 @@ onMounted(async () => {
       </table>
     </div>
     <br />
-    <div class="spotify-button">
+    <div class="spotify-content">
       <div style="display: inline-block; vertical-align: middle">
         <img
           src="../../../public/Spotify_Logo_CMYK_Green.png"
@@ -256,14 +256,14 @@ onMounted(async () => {
       <div style="display: inline-block; vertical-align: middle">
         <button
           :disabled="!spotifyLink"
-          class="bg-blue-400 hover:bg-blue-600 font-bold py-1 px-4 mx-2 border border-blue-600 rounded disabled:opacity-50 disabled:pointer-events-none"
+          class="spotify-button bg-blue-400 hover:bg-blue-600 font-bold py-1 px-4 mx-2 border border-blue-600 rounded disabled:opacity-50 disabled:pointer-events-none"
         >
           <a :href="spotifyLink" target="_blank" class="text-white"
             >この曲を再生する</a
           >
         </button>
       </div>
-      <div v-if="!spotifyLink" class="my-2 text-xs">
+      <div v-if="!spotifyLink" class="no-spotify my-2 text-xs">
         <p>登録されているSpotifyでの音源情報がないため再生ができません。</p>
       </div>
     </div>

--- a/src/components/recordings/RecordingInWork.vue
+++ b/src/components/recordings/RecordingInWork.vue
@@ -53,7 +53,7 @@ onMounted(async () => {
   </div>
   <div v-else-if="recordingList">
     <h1 class="text-2xl my-4 max-w-xl">曲群一覧</h1>
-    <table class="table-auto my-4">
+    <table class="work-table table-auto my-4">
       <thead>
         <tr>
           <th class="px-4 py-2 border w-[400px] bg-blue-100">曲名</th>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -194,7 +194,7 @@ onMounted(() => {
                   .join(' ')
               }}
             </p>
-            <p class="my-1 text-xs">
+            <p class="release-date my-1 text-xs">
               {{ 'リリース日: ' + recording.firstReleaseDate }}
             </p>
           </td>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -148,7 +148,7 @@ onMounted(() => {
         </div>
       </form>
     </div>
-    <p>
+    <p class="recording-search-number">
       {{
         '検索結果 ' +
         totalItems +

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -96,7 +96,7 @@ onMounted(() => {
   <div v-else-if="refRecordingData.length !== 0" class="container">
     <h1 class="text-2xl my-4 max-w-xl">音源検索結果</h1>
     <p>音源をクリックすると、その音源に関わったスタッフを確認できます。</p>
-    <div class="my-2 border md:w-[450px] w-[250px] rounded-md">
+    <div class="recording-filter my-2 border md:w-[450px] w-[250px] rounded-md">
       <form @submit.prevent="applyFilter">
         <div class="border-b-2 px-4 bg-blue-200">
           <p class="text-lg mb-2 font-bold pt-2">絞り込み</p>
@@ -159,7 +159,7 @@ onMounted(() => {
         '件'
       }}
     </p>
-    <table class="table-auto my-4">
+    <table class="recording-search-table table-auto my-4">
       <thead>
         <tr>
           <th class="px-4 py-2 border w-[390px] md:w-[460px] bg-blue-100">

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -201,7 +201,7 @@ onMounted(() => {
         </tr>
       </tbody>
     </table>
-    <div v-if="totalItems > 100">
+    <div v-if="totalItems > 100" class="pagination">
       <vue-awesome-paginate
         v-model="currentPage"
         :total-items="totalItems"

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -135,7 +135,7 @@ const currentPage = ref(1)
         '件'
       }}
     </p>
-    <table class="table-auto my-4">
+    <table class="filtered-recording-search-table table-auto my-4">
       <thead>
         <tr>
           <th class="px-4 py-2 border w-[390px] md:w-[460px] bg-blue-100">

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -170,7 +170,7 @@ const currentPage = ref(1)
                   .join(' ')
               }}
             </p>
-            <p class="my-1 text-xs">
+            <p class="release-date my-1 text-xs">
               {{ 'リリース日: ' + recording.firstReleaseDate }}
             </p>
           </td>
@@ -187,7 +187,7 @@ const currentPage = ref(1)
       />
     </div>
   </div>
-  <div v-else>
+  <div v-else class="no-filtered-recording">
     <h1 class="text-2xl my-4 max-w-xl">Not Found!</h1>
     <p>条件に該当する音源はありませんでした。</p>
   </div>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -124,7 +124,7 @@ const currentPage = ref(1)
   </div>
   <div v-else-if="filteredDataLength !== 0">
     <h1 class="text-2xl my-4 max-w-xl">絞り込み結果</h1>
-    <p>
+    <p class="filtered-recording-search-number">
       {{
         '検索結果 ' +
         filteredDataLength +

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -177,7 +177,7 @@ const currentPage = ref(1)
         </tr>
       </tbody>
     </table>
-    <div v-if="filteredDataLength > 100">
+    <div v-if="filteredDataLength > 100" class="pagination">
       <vue-awesome-paginate
         v-model="currentPage"
         :total-items="filteredDataLength"


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credits_spot/issues/220

## 概要
テストコードがパッと見何をしているかわかりにくくなっているので修正した。
* 不要なコメントを削除
* 不要なテストを削除
* テンプレートにクラス等を付与し、テストでセレクタを指定するようにした
* 一部テストを分割した