### PR TITLE
APIへのfetchに失敗したときの表示を追加

### DIFF
--- a/cypress/component/ArtistDetail.cy.ts
+++ b/cypress/component/ArtistDetail.cy.ts
@@ -621,3 +621,52 @@ describe('Check recording of songwriter and staff results are not change by usin
     cy.get('.artist-recording-number').contains('105 件中 101 〜 105件')
   })
 })
+
+describe('False fetch request', () => {
+  it('False songwriter and staff recording request', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/artist/53bfc28e-2c48-4776-8949-1953c78dd187?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
+      { forceNetworkError: true,
+        fixture: 'mock_nakatayasutaka_relationship.json' }
+    ).as('yasutakaRelationshipRequest')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording?artist=53bfc28e-2c48-4776-8949-1953c78dd187&offset=0&limit=100&fmt=json',
+      { fixture: 'mock_nakatayasutaka_recording_page1.json' }
+    ).as('yasutakaRecording1PageRequest')
+    cy.mount(ArtistDetail, {
+      props: { id: '53bfc28e-2c48-4776-8949-1953c78dd187' },
+    } as OptionsParam)
+    cy.wait('@yasutakaRelationshipRequest')
+
+    cy.contains('時間を置いて再度お試しください。')
+    cy.contains('作詞作曲した音源').should('not.be')
+    cy.contains('スタッフとして関わった音源').should('not.be')
+    cy.contains('アーティストとして関わった音源').should('not.be')
+  })
+
+  it('False artist recording request', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/artist/53bfc28e-2c48-4776-8949-1953c78dd187?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
+      { fixture: 'mock_nakatayasutaka_relationship.json' }
+    ).as('yasutakaRelationshipRequest')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording?artist=53bfc28e-2c48-4776-8949-1953c78dd187&offset=0&limit=100&fmt=json',
+      { forceNetworkError: true,
+        fixture: 'mock_nakatayasutaka_recording_page1.json' }
+    ).as('yasutakaRecording1PageRequest')
+    cy.mount(ArtistDetail, {
+      props: { id: '53bfc28e-2c48-4776-8949-1953c78dd187' },
+    } as OptionsParam)
+    cy.wait('@yasutakaRelationshipRequest')
+    cy.wait('@yasutakaRecording1PageRequest')
+
+    cy.contains('時間を置いて再度お試しください。')
+    cy.contains('作詞作曲した音源').should('not.be')
+    cy.contains('スタッフとして関わった音源').should('not.be')
+    cy.contains('アーティストとして関わった音源').should('not.be')
+  })
+})

--- a/cypress/component/ArtistDetail.cy.ts
+++ b/cypress/component/ArtistDetail.cy.ts
@@ -627,8 +627,10 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/53bfc28e-2c48-4776-8949-1953c78dd187?inc=recording-rels+artist-rels+artist-credits+work-rels&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_nakatayasutaka_relationship.json' }
+      {
+        forceNetworkError: true,
+        fixture: 'mock_nakatayasutaka_relationship.json',
+      }
     ).as('yasutakaRelationshipRequest')
     cy.intercept(
       'GET',
@@ -655,8 +657,10 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording?artist=53bfc28e-2c48-4776-8949-1953c78dd187&offset=0&limit=100&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_nakatayasutaka_recording_page1.json' }
+      {
+        forceNetworkError: true,
+        fixture: 'mock_nakatayasutaka_recording_page1.json',
+      }
     ).as('yasutakaRecording1PageRequest')
     cy.mount(ArtistDetail, {
       props: { id: '53bfc28e-2c48-4776-8949-1953c78dd187' },

--- a/cypress/component/ArtistSearch.cy.ts
+++ b/cypress/component/ArtistSearch.cy.ts
@@ -118,8 +118,7 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/artist/?query=artist:%E5%B0%8F%E5%AE%A4%E5%93%B2%E5%93%89&offset=0&limit=100&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_komurotetsuya_page1.json' }
+      { forceNetworkError: true, fixture: 'mock_komurotetsuya_page1.json' }
     ).as('komurotetsuya1PageRequest')
     cy.mount(ArtistSearch, { query: { term: '小室哲哉' } })
     cy.wait('@komurotetsuya1PageRequest')

--- a/cypress/component/ArtistSearch.cy.ts
+++ b/cypress/component/ArtistSearch.cy.ts
@@ -112,3 +112,19 @@ describe('No results', () => {
     })
   })
 })
+
+describe('False fetch request', () => {
+  it('False artist search request', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/artist/?query=artist:%E5%B0%8F%E5%AE%A4%E5%93%B2%E5%93%89&offset=0&limit=100&fmt=json',
+      { forceNetworkError: true,
+        fixture: 'mock_komurotetsuya_page1.json' }
+    ).as('komurotetsuya1PageRequest')
+    cy.mount(ArtistSearch, { query: { term: '小室哲哉' } })
+    cy.wait('@komurotetsuya1PageRequest')
+
+    cy.contains('時間を置いて再度お試しください。')
+    cy.contains('小室哲哉').should('not.be')
+  })
+})

--- a/cypress/component/RecordingDetail.cy.ts
+++ b/cypress/component/RecordingDetail.cy.ts
@@ -60,8 +60,7 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/02689e6a-9a9f-4415-9218-bb3da1dc1a87?inc=artist-credits+recording-rels+work-rels+work-level-rels+artist-rels+isrcs&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_suiheisen.json' }
+      { forceNetworkError: true, fixture: 'mock_suiheisen.json' }
     ).as('suiheisenRequest')
     cy.intercept(
       'GET',
@@ -86,8 +85,7 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://api.spotify.com/v1/search?query=isrc%3AJPPO02100907&type=track&offset=0&limit=20',
-      { forceNetworkError: true ,
-        fixture: 'mock_spotify_suiheisen.json' }
+      { forceNetworkError: true, fixture: 'mock_spotify_suiheisen.json' }
     ).as('suiheisenSpotifyRequest')
     cy.mount(RecordingDetail, {
       props: { id: '02689e6a-9a9f-4415-9218-bb3da1dc1a87' },

--- a/cypress/component/RecordingInWork.cy.ts
+++ b/cypress/component/RecordingInWork.cy.ts
@@ -26,8 +26,7 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/work/30a33711-0db8-3fc7-a3c8-f42426bdf43b?inc=recording-rels+artist-credits&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_debby.json' }
+      { forceNetworkError: true, fixture: 'mock_debby.json' }
     ).as('debbyRequest')
     cy.mount(RecordingInWork, {
       props: { id: '30a33711-0db8-3fc7-a3c8-f42426bdf43b' },

--- a/cypress/component/RecordingInWork.cy.ts
+++ b/cypress/component/RecordingInWork.cy.ts
@@ -13,9 +13,28 @@ describe('More than 100 recordings', () => {
     } as OptionsParam)
     cy.wait('@debbyRequest')
     cy.get('h1').contains('曲群一覧')
+    cy.contains('Waltz for Debby')
 
     cy.get('.work-table > tbody > tr').should(($trs) => {
       expect($trs, '127 items').to.have.length(127)
     })
+  })
+})
+
+describe('More than 100 recordings', () => {
+  it('False fetch request', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/work/30a33711-0db8-3fc7-a3c8-f42426bdf43b?inc=recording-rels+artist-credits&fmt=json',
+      { forceNetworkError: true,
+        fixture: 'mock_debby.json' }
+    ).as('debbyRequest')
+    cy.mount(RecordingInWork, {
+      props: { id: '30a33711-0db8-3fc7-a3c8-f42426bdf43b' },
+    } as OptionsParam)
+    cy.wait('@debbyRequest')
+
+    cy.contains('時間を置いて再度お試しください。')
+    cy.contains('Waltz for Debby').should('not.be')
   })
 })

--- a/cypress/component/RecordingInWork.cy.ts
+++ b/cypress/component/RecordingInWork.cy.ts
@@ -21,8 +21,8 @@ describe('More than 100 recordings', () => {
   })
 })
 
-describe('More than 100 recordings', () => {
-  it('False fetch request', () => {
+describe('False fetch request', () => {
+  it('False fetch work', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/work/30a33711-0db8-3fc7-a3c8-f42426bdf43b?inc=recording-rels+artist-credits&fmt=json',

--- a/cypress/component/RecordingSearch.cy.ts
+++ b/cypress/component/RecordingSearch.cy.ts
@@ -123,3 +123,19 @@ describe('No result', () => {
     })
   })
 })
+
+describe('RecordingSearch tests', () => {
+  it('Less than 100 recording search result', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording/?query=recording:%E3%83%9F%E3%83%83%E3%82%AF%E3%82%B9%E3%83%8A%E3%83%83%E3%83%84&offset=0&limit=100&fmt=json',
+      { forceNetworkError: true,
+        fixture: 'mock_mixednuts.json' }
+    ).as('mixednutsRequest')
+    cy.mount(RecordingSearch, { query: { term: 'ミックスナッツ' } })
+    cy.wait('@mixednutsRequest')
+
+    cy.contains('時間を置いて再度お試しください。')
+    cy.contains('ミックスナッツ').should('not.be')
+  })
+})

--- a/cypress/component/RecordingSearch.cy.ts
+++ b/cypress/component/RecordingSearch.cy.ts
@@ -129,8 +129,7 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E3%83%9F%E3%83%83%E3%82%AF%E3%82%B9%E3%83%8A%E3%83%83%E3%83%84&offset=0&limit=100&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_mixednuts.json' }
+      { forceNetworkError: true, fixture: 'mock_mixednuts.json' }
     ).as('mixednutsRequest')
     cy.mount(RecordingSearch, { query: { term: 'ミックスナッツ' } })
     cy.wait('@mixednutsRequest')

--- a/cypress/component/RecordingSearch.cy.ts
+++ b/cypress/component/RecordingSearch.cy.ts
@@ -124,8 +124,8 @@ describe('No result', () => {
   })
 })
 
-describe('RecordingSearch tests', () => {
-  it('Less than 100 recording search result', () => {
+describe('False fetch request', () => {
+  it('False fetch recording search', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E3%83%9F%E3%83%83%E3%82%AF%E3%82%B9%E3%83%8A%E3%83%83%E3%83%84&offset=0&limit=100&fmt=json',

--- a/cypress/component/RecordingSearchFilter.cy.ts
+++ b/cypress/component/RecordingSearchFilter.cy.ts
@@ -499,8 +499,7 @@ describe('False fetch request', () => {
     cy.intercept(
       'GET',
       'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=400&limit=100&fmt=json',
-      { forceNetworkError: true,
-        fixture: 'mock_ue5.json' }
+      { forceNetworkError: true, fixture: 'mock_ue5.json' }
     ).as('ue5Request')
     cy.mount(RecordingSearchFilter, {
       query: { term: '上を向いて歩こう', partialMatch: 'true' },

--- a/cypress/component/RecordingSearchFilter.cy.ts
+++ b/cypress/component/RecordingSearchFilter.cy.ts
@@ -473,3 +473,45 @@ describe('No results', () => {
     })
   })
 })
+
+describe('False fetch request', () => {
+  it('False recording fetch', () => {
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=0&limit=100&fmt=json',
+      { fixture: 'mock_ue1.json' }
+    ).as('ue1Request')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=100&limit=100&fmt=json',
+      { fixture: 'mock_ue2.json' }
+    ).as('ue2Request')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=200&limit=100&fmt=json',
+      { fixture: 'mock_ue3.json' }
+    ).as('ue3Request')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=300&limit=100&fmt=json',
+      { fixture: 'mock_ue4.json' }
+    ).as('ue4Request')
+    cy.intercept(
+      'GET',
+      'https://musicbrainz.org/ws/2/recording/?query=recording:%E4%B8%8A%E3%82%92%E5%90%91%E3%81%84%E3%81%A6%E6%AD%A9%E3%81%93%E3%81%86&offset=400&limit=100&fmt=json',
+      { forceNetworkError: true,
+        fixture: 'mock_ue5.json' }
+    ).as('ue5Request')
+    cy.mount(RecordingSearchFilter, {
+      query: { term: '上を向いて歩こう', partialMatch: 'true' },
+    })
+    cy.wait('@ue1Request')
+    cy.wait('@ue2Request')
+    cy.wait('@ue3Request')
+    cy.wait('@ue4Request')
+    cy.wait('@ue5Request')
+
+    cy.contains('時間を置いて再度お試しください。')
+    cy.contains('上を向いて歩こう').should('not.be')
+  })
+})

--- a/cypress/e2e/flow_recording_search.spec.cy.ts
+++ b/cypress/e2e/flow_recording_search.spec.cy.ts
@@ -622,7 +622,7 @@ describe('Check spotify button', () => {
 
     cy.get('.spotify-button').should('be.disabled')
     cy.get('.no-spotify > p').contains(
-      '登録されているSpotifyでの音源情報がないため再生ができません。'
+      '登録されているSpotifyでの音源情報がないか、一時的なエラーのため再生ができません。'
     )
   })
 })

--- a/src/components/FetchError.vue
+++ b/src/components/FetchError.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="fetch-error">
+    <h1 class="fetch-error-caption text-2xl my-4 max-w-xl">Temporarily Error!</h1>
+    <p>時間を置いて再度お試しください。</p>
+  </div>
+</template>

--- a/src/components/FetchError.vue
+++ b/src/components/FetchError.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="fetch-error">
-    <h1 class="fetch-error-caption text-2xl my-4 max-w-xl">Temporarily Error!</h1>
+    <h1 class="fetch-error-caption text-2xl my-4 max-w-xl">
+      Temporarily Error!
+    </h1>
     <p>時間を置いて再度お試しください。</p>
   </div>
 </template>

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, defineProps } from 'vue'
 import NotFound from '../NotFound.vue'
 import NowLoading from '../NowLoading.vue'
+import FetchError from '../FetchError.vue'
 import {
   ArtistData,
   RecordingCredit,
@@ -16,6 +17,7 @@ const props = defineProps<Props>()
 const refArtistData = ref<ArtistData>()
 const refArtistRecording = ref<ArtistRecording[]>()
 const isLoading = ref(false)
+const fetchError = ref(false)
 
 const currentPage = ref(1)
 const totalItems = ref<number>(NaN)
@@ -59,6 +61,7 @@ onMounted(async () => {
     onClickHandler(1)
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   } finally {
     isLoading.value = false
   }
@@ -89,6 +92,9 @@ const onClickHandler = async (page: number) => {
 <template>
   <div v-if="isLoading">
     <NowLoading />
+  </div>
+  <div v-else-if="fetchError">
+    <FetchError />
   </div>
   <div v-else-if="refArtistData || refArtistRecording">
     <h1 class="artist-name text-2xl my-4 max-w-xl break-all">

--- a/src/components/artists/ArtistDetail.vue
+++ b/src/components/artists/ArtistDetail.vue
@@ -85,6 +85,7 @@ const onClickHandler = async (page: number) => {
     totalItems.value = recordingData['recording-count']
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   }
 }
 </script>

--- a/src/components/artists/ArtistSearch.vue
+++ b/src/components/artists/ArtistSearch.vue
@@ -4,6 +4,7 @@ import { useRoute, RouterLink, onBeforeRouteUpdate } from 'vue-router'
 import { ArtistData } from '../../types/artist/ArtistSearch'
 import NowLoading from '../NowLoading.vue'
 import NoResults from '../NoResults.vue'
+import FetchError from '../FetchError.vue'
 
 onBeforeRouteUpdate((to, from, next) => {
   artistTerm.value = (to.query.term as string) || ''
@@ -17,6 +18,7 @@ const route = useRoute()
 const artistTerm = ref((route.query.term as string) || '')
 const refArtistData = ref<ArtistData[]>([])
 const isLoading = ref(false)
+const fetchError = ref(false)
 
 const onClickHandler = async (page: number, artistTerm: string) => {
   if (!artistTerm) {
@@ -40,6 +42,7 @@ const onClickHandler = async (page: number, artistTerm: string) => {
     totalItems.value = data.count
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   } finally {
     isLoading.value = false
   }
@@ -56,6 +59,9 @@ onMounted(() => {
 <template>
   <div v-if="isLoading">
     <NowLoading />
+  </div>
+  <div v-else-if="fetchError">
+    <FetchError />
   </div>
   <div v-else-if="refArtistData.length !== 0">
     <h1 class="text-2xl my-4 max-w-xl">人物検索結果</h1>

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -55,7 +55,6 @@ async function fetchSpotify() {
         )
         const spotifyData = await spotifyRes.json()
         spotifyLink.value = spotifyData.tracks.items[0]?.external_urls.spotify
-        console.log(spotifyLink.value)
       } catch (error) {
         console.error(error)
         spotifyFetchError.value = true

--- a/src/components/recordings/RecordingDetail.vue
+++ b/src/components/recordings/RecordingDetail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import NotFound from '../NotFound.vue'
 import NowLoading from '../NowLoading.vue'
+import FetchError from '../FetchError.vue'
 import {
   RecordingData,
   Artists,
@@ -20,6 +21,8 @@ const spotifyLink = ref<string>()
 const clientId = import.meta.env.VITE_CLIENT_ID
 const secretId = import.meta.env.VITE_CLIENT_SECRET
 const isLoading = ref(false)
+const fetchError = ref(false)
+const spotifyFetchError = ref(false)
 
 onMounted(async () => {
   try {
@@ -123,13 +126,16 @@ onMounted(async () => {
           spotifyLink.value = spotifyData.tracks.items[0]?.external_urls.spotify
         } catch (error) {
           console.error(error)
+          spotifyFetchError.value = true
         }
       })
       .catch((error) => {
         console.error(error)
+        spotifyFetchError.value = true
       })
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   } finally {
     isLoading.value = false
   }
@@ -139,6 +145,9 @@ onMounted(async () => {
 <template>
   <div v-if="isLoading">
     <NowLoading />
+  </div>
+  <div v-else-if="fetchError">
+    <FetchError />
   </div>
   <div v-else-if="refRecordingData">
     <h1 class="recording-title text-2xl my-4 max-w-xl break-all">
@@ -258,7 +267,7 @@ onMounted(async () => {
       </div>
       <div style="display: inline-block; vertical-align: middle">
         <button
-          :disabled="!spotifyLink"
+          :disabled="!spotifyLink || spotifyFetchError"
           class="spotify-button bg-blue-400 hover:bg-blue-600 font-bold py-1 px-4 mx-2 border border-blue-600 rounded disabled:opacity-50 disabled:pointer-events-none"
         >
           <a :href="spotifyLink" target="_blank" class="text-white"
@@ -268,6 +277,9 @@ onMounted(async () => {
       </div>
       <div v-if="!spotifyLink" class="no-spotify my-2 text-xs">
         <p>登録されているSpotifyでの音源情報がないため再生ができません。</p>
+      </div>
+      <div v-else-if="spotifyFetchError" class="spotify-fetch-error my-2 text-xs">
+        <p>一時的なエラーによりSpotifyへのリンクが取得できません。</p>
       </div>
     </div>
   </div>

--- a/src/components/recordings/RecordingInWork.vue
+++ b/src/components/recordings/RecordingInWork.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import NotFound from '../NotFound.vue'
 import NowLoading from '../NowLoading.vue'
+import FetchError from '../FetchError.vue'
 import { RecordInWork } from '../../types/artist/ArtistDetail'
 import { ArtistCredit } from '../../types/recording/RecordingSearch'
 
@@ -13,6 +14,7 @@ const props = defineProps<Props>()
 const workId = ref(props.id)
 const recordingList = ref<RecordInWork[]>()
 const isLoading = ref(false)
+const fetchError = ref(false)
 
 onMounted(async () => {
   try {
@@ -41,6 +43,7 @@ onMounted(async () => {
     recordingList.value = recordingInWork
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   } finally {
     isLoading.value = false
   }
@@ -50,6 +53,9 @@ onMounted(async () => {
 <template>
   <div v-if="isLoading">
     <NowLoading />
+  </div>
+  <div v-else-if="fetchError">
+    <FetchError />
   </div>
   <div v-else-if="recordingList">
     <h1 class="text-2xl my-4 max-w-xl">曲群一覧</h1>

--- a/src/components/recordings/RecordingSearch.vue
+++ b/src/components/recordings/RecordingSearch.vue
@@ -8,6 +8,7 @@ import {
 } from '../../types/recording/RecordingSearch'
 import NowLoading from '../NowLoading.vue'
 import NoResults from '../NoResults.vue'
+import FetchError from '../FetchError.vue'
 
 onBeforeRouteUpdate((to, from, next) => {
   recordingTerm.value = (to.query.term as string) || ''
@@ -24,6 +25,7 @@ const refRecordingData = ref<SearchRecordingData[]>([])
 const selectedFilter = ref<Array<string>>([])
 const artistName = ref()
 const isLoading = ref(false)
+const fetchError = ref(false)
 
 const onClickHandler = async (page: number, recordingTerm: string) => {
   if (!recordingTerm) {
@@ -57,6 +59,7 @@ const onClickHandler = async (page: number, recordingTerm: string) => {
     totalItems.value = data.count
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   } finally {
     isLoading.value = false
   }
@@ -92,6 +95,9 @@ onMounted(() => {
 <template>
   <div v-if="isLoading">
     <NowLoading />
+  </div>
+  <div v-else-if="fetchError">
+    <FetchError />
   </div>
   <div v-else-if="refRecordingData.length !== 0" class="container">
     <h1 class="text-2xl my-4 max-w-xl">音源検索結果</h1>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -6,6 +6,7 @@ import {
   SearchRecordingData,
 } from '../../types/recording/RecordingSearch'
 import NowLoading from '../NowLoading.vue'
+import FetchError from '../FetchError.vue'
 
 const route = useRoute()
 const recordingTerm = (route.query.term as string) || ''
@@ -124,9 +125,8 @@ const currentPage = ref(1)
   <div v-if="isLoading">
     <NowLoading />
   </div>
-  <div v-else-if="fetchError" class="fetch-error">
-    <h1 class="text-2xl my-4 max-w-xl">Temporarily Error!</h1>
-    <p>時間を置いて再度お試しください。</p>
+  <div v-else-if="fetchError">
+    <FetchError />
   </div>
   <div v-else-if="filteredDataLength !== 0">
     <h1 class="text-2xl my-4 max-w-xl">絞り込み結果</h1>

--- a/src/components/recordings/RecordingSearchFilter.vue
+++ b/src/components/recordings/RecordingSearchFilter.vue
@@ -16,6 +16,7 @@ const totalItems = ref<number>(0)
 let filteredDataLength = 0
 let filteredData: SearchRecordingData[] = []
 const isLoading = ref(false)
+const fetchError = ref(false)
 
 const refRecordingData = ref<SearchRecordingData[]>([])
 const refRecordingDataArray = ref<Array<SearchRecordingData[]>>([])
@@ -75,6 +76,7 @@ onMounted(async () => {
     onClickHandler(currentPage.value)
   } catch {
     console.error('Error fetching data:', Error)
+    fetchError.value = true
   } finally {
     isLoading.value = false
   }
@@ -121,6 +123,10 @@ const currentPage = ref(1)
 <template>
   <div v-if="isLoading">
     <NowLoading />
+  </div>
+  <div v-else-if="fetchError" class="fetch-error">
+    <h1 class="text-2xl my-4 max-w-xl">Temporarily Error!</h1>
+    <p>時間を置いて再度お試しください。</p>
   </div>
   <div v-else-if="filteredDataLength !== 0">
     <h1 class="text-2xl my-4 max-w-xl">絞り込み結果</h1>


### PR DESCRIPTION
## issue
https://github.com/fuwa-syugyo/credits_spot/issues/225

## 概要
* MusicBrainz APIとSpotify Web APIへのfetchに失敗したときに表示をするようにした

* 音源詳細画面のSpotifyリンクがないときの注意書きを変更
Spotify APIへのfetchが失敗した場合と、そもそもSpotifyに楽曲データがない場合で表示を分けたかったが、Cypressのテストで`forceNetworkError: true`を使って強制的にネットワークエラーを発生させるといずれもSpotifyに楽曲データがない場合と同じになってしまう。
処理を見直せば分けられる可能性があるので、ひとまず別issueに切り出した。https://github.com/fuwa-syugyo/credits_spot/issues/226
※人物詳細画面ではアーティストとして関わった楽曲＆それ以外でfetchリクエストが計2種類あるが、どちらかのリクエストが失敗した時点で画面全体に失敗の表示を出すようにした。
(片方だけ表示すると見た目が良くないため。)

* `src/components/recordings/RecordingDetail.vue` の Spotify Web APIへのfetch処理を`fetchSpotify()`に切り出した